### PR TITLE
Add --get-gst-launch flag to pipeline applications

### DIFF
--- a/doc/user_guide/running_applications.md
+++ b/doc/user_guide/running_applications.md
@@ -86,18 +86,18 @@ All applications share a common set of arguments for controlling the input sourc
 
 ## Command-Line Argument Reference
 
-| Flag(s)                  | Description                                                                                                                                   |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--input, -i <source>`   | Specifies the input source. Common options include: `rpi`, `usb`, a device path like `/dev/video0`, or a path to a video file.                |
-| `--arch <architecture>`  | Manually sets the Hailo device architecture (e.g., `hailo8`, `hailo8l`, `hailo10h`). If not provided, the system will auto-detect the device. |
-| `--hef-path <path>`      | Path to a custom compiled HEF model file, allowing you to run your own trained models.                                                        |
-| `--show-fps, -f`         | Displays a real-time Frames-Per-Second (FPS) counter on the output video window.                                                              |
-| `--frame-rate, -r <fps>` | Sets the target input frame rate for the video source. Defaults to 30.                                                                        |
-| `--disable-sync`         | Disables display synchronization to run the pipeline at maximum speed. This is ideal for benchmarking processing throughput.                  |
-| `--disable-callback`     | Disables user-defined Python callback functions. Frame counting for watchdog continues. Use for performance benchmarking.                     |
-| `--dump-dot`             | Generates a `pipeline.dot` file, which is a graph of the GStreamer pipeline that can be visualized with tools like Graphviz.                  |
-| `--labels-json <path>`   | Path to a custom JSON file containing the labels for the classes your model can detect or classify.                                           |
-| `--use-frame, -u`        | In applications with a Python callback, this flag indicates that the callback is responsible for providing the frame for display.             |
-| `--enable-watchdog`      | Monitors the pipeline for stalls (no frames processed for 5s) and automatically rebuilds it. Works with --disable-callback.                   |
-| `--log-level <level>`    | Set logging level: debug, info, warning, error, critical. Default: info. Can also use --debug for debug level.                                |
-| `--log-file <path>`      | Optional log file path for persistent logging. Also respects $HAILO_LOG_FILE environment variable.                                            |
+| Flag(s)                  | Description                                                                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--input, -i <source>`   | Specifies the input source. Common options include: `rpi`, `usb`, a device path like `/dev/video0`, or a path to a video file.                     |
+| `--arch <architecture>`  | Manually sets the Hailo device architecture (e.g., `hailo8`, `hailo8l`, `hailo10h`). If not provided, the system will auto-detect the device.      |
+| `--hef-path <path>`      | Path to a custom compiled HEF model file, allowing you to run your own trained models.                                                             |
+| `--show-fps, -f`         | Displays a real-time Frames-Per-Second (FPS) counter on the output video window.                                                                   |
+| `--frame-rate, -r <fps>` | Sets the target input frame rate for the video source. Defaults to 30.                                                                             |
+| `--disable-sync`         | Disables display synchronization to run the pipeline at maximum speed. This is ideal for benchmarking processing throughput.                       |
+| `--disable-callback`     | Disables user-defined Python callback functions. Frame counting for watchdog continues. Use for performance benchmarking.                          |
+| `--dump-dot`             | Generates a `pipeline.dot` file, which is a graph of the GStreamer pipeline that can be visualized with tools like Graphviz.                       |
+| `--labels-json <path>`   | Path to a custom JSON file containing the labels for the classes your model can detect or classify.                                                |
+| `--use-frame, -u`        | In applications with a Python callback, this flag indicates that the callback is responsible for providing the frame for display.                  |
+| `--enable-watchdog`      | Monitors the pipeline for stalls (no frames processed for 5s) and automatically rebuilds it. Works with --disable-callback.                        |
+| `--log-level <level>`    | Set logging level: debug, info, warning, error, critical. Default: configured in config.yaml (usually INFO). Can also use --debug for debug level. |
+| `--log-file <path>`      | Optional log file path for persistent logging. Also respects $HAILO_LOG_FILE environment variable.                                                 |

--- a/hailo_apps/config/config.yaml
+++ b/hailo_apps/config/config.yaml
@@ -1,5 +1,6 @@
 hailort_version: "auto" # Options: "auto" (detect from device), "latest" (latest version), or specific version
 tappas_version: "auto" # Version of the Tappas model to use, set to "auto" to detect automatically
+log_level: "INFO" # Default logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 model_zoo_version: "v2.17.0" # Version of the model zoo to use , v2.17 for hailo8 , v5.1.0 for hailo10h
 host_arch: "auto" # Options: "rpi" (Raspberry Pi), "x86" (desktop/server), "arm" (generic ARM board) or "auto" (detect from device)
 hailo_arch: "auto" # Options: "hailo8", "hailo8l", "hailo10h" or "auto" (detect from device)

--- a/hailo_apps/installation/config_utils.py
+++ b/hailo_apps/installation/config_utils.py
@@ -52,6 +52,7 @@ try:
         VALID_TAPPAS_VERSION,
         VIRTUAL_ENV_NAME_DEFAULT,
         VIRTUAL_ENV_NAME_KEY,
+        LOG_LEVEL_KEY,
     )
 except ImportError:
     # Fallback: import from path
@@ -88,6 +89,7 @@ except ImportError:
         VALID_TAPPAS_VERSION = defines_module.VALID_TAPPAS_VERSION
         VIRTUAL_ENV_NAME_DEFAULT = defines_module.VIRTUAL_ENV_NAME_DEFAULT
         VIRTUAL_ENV_NAME_KEY = defines_module.VIRTUAL_ENV_NAME_KEY
+        LOG_LEVEL_KEY = defines_module.LOG_LEVEL_KEY
     else:
         raise ImportError(f"Could not find defines.py at {defines_path}")
 
@@ -122,6 +124,7 @@ def load_default_config() -> dict:
         TAPPAS_VARIANT_KEY: TAPPAS_VARIANT_DEFAULT,
         RESOURCES_PATH_KEY: DEFAULT_RESOURCES_SYMLINK_PATH,
         VIRTUAL_ENV_NAME_KEY: VIRTUAL_ENV_NAME_DEFAULT,
+        LOG_LEVEL_KEY: "INFO",
     }
     hailo_logger.debug(f"Loaded default configuration: {default_cfg}")
     return default_cfg
@@ -139,6 +142,7 @@ def validate_config(config: dict) -> bool:
         HAILO_ARCH_KEY: VALID_HAILO_ARCH,
         SERVER_URL_KEY: VALID_SERVER_URL,
         TAPPAS_VARIANT_KEY: VALID_TAPPAS_VARIANT,
+        LOG_LEVEL_KEY: ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     }
     for key, valid_choices in valid_map.items():
         val = config.get(key)
@@ -181,7 +185,7 @@ def _load_resources_config() -> dict:
     global _RESOURCES_CONFIG_CACHE
     if _RESOURCES_CONFIG_CACHE is not None:
         return _RESOURCES_CONFIG_CACHE
-    
+
     try:
         from hailo_apps.python.core.common.defines import DEFAULT_RESOURCES_CONFIG_PATH
     except ImportError:
@@ -189,12 +193,12 @@ def _load_resources_config() -> dict:
         DEFAULT_RESOURCES_CONFIG_PATH = str(
             current_file.parent.parent / "config" / "resources_config.yaml"
         )
-    
+
     config_path = Path(DEFAULT_RESOURCES_CONFIG_PATH)
     if not config_path.is_file():
         hailo_logger.warning(f"Resources config not found at {config_path}")
         return {}
-    
+
     _RESOURCES_CONFIG_CACHE = load_config(config_path)
     return _RESOURCES_CONFIG_CACHE
 
@@ -214,11 +218,11 @@ def _get_arch_models(config: dict, app_name: str, arch: str | None = None) -> di
     app_config = config.get(app_name)
     if not isinstance(app_config, dict) or "models" not in app_config:
         return None
-    
+
     models_config = app_config["models"]
     if arch is None:
         return models_config
-    
+
     arch_models = models_config.get(arch)
     return arch_models if isinstance(arch_models, dict) else None
 
@@ -279,7 +283,7 @@ def get_supported_architectures_for_app(app_name: str, resources_config: dict | 
     models_config = _get_arch_models(config, app_name)
     if not models_config:
         return []
-    
+
     supported = []
     for arch, arch_models in models_config.items():
         if isinstance(arch_models, dict):
@@ -321,7 +325,7 @@ def get_model_info(app_name: str, arch: str, model_name: str, resources_config: 
     arch_models = _get_arch_models(config, app_name, arch)
     if not arch_models:
         return None
-    
+
     # Search in default, then extra
     return _find_model_entry(arch_models.get("default"), model_name) or \
            _find_model_entry(arch_models.get("extra"), model_name)
@@ -333,7 +337,7 @@ def is_gen_ai_app(app_name: str, resources_config: dict | None = None) -> bool:
     models_config = _get_arch_models(config, app_name)
     if not models_config:
         return False
-    
+
     for arch_models in models_config.values():
         if isinstance(arch_models, dict):
             if _has_source(arch_models.get("default"), "gen-ai-mz") or \

--- a/hailo_apps/python/core/common/core.py
+++ b/hailo_apps/python/core/common/core.py
@@ -1,4 +1,4 @@
-"""Core helpers: arch detection, parser, buffer utils."""
+"""Core helpers: arch detection, parser, buffer utils, model resolution."""
 
 import argparse
 import os
@@ -475,3 +475,229 @@ class FIFODropQueue(queue.Queue):
             hailo_logger.debug("Queue full, dropping oldest item.")
             self.get_nowait()
         super().put(item, block, timeout)
+
+
+# =============================================================================
+# Model Resolution and Listing
+# =============================================================================
+
+def list_models_for_app(app_name: str, arch: str | None = None) -> None:
+    """
+    List all available models for an application and exit.
+    
+    Args:
+        app_name: The app name from resources config (e.g., 'detection', 'vlm_chat')
+        arch: Hailo architecture. If None, auto-detects.
+    """
+    try:
+        from hailo_apps.installation.config_utils import (
+            get_default_models_for_app_and_arch,
+            get_extra_models_for_app_and_arch,
+            get_supported_architectures_for_app,
+            is_gen_ai_app,
+        )
+    except ImportError:
+        print("Error: Could not import config_utils. Run 'pip install -e .' first.")
+        sys.exit(1)
+    
+    # Detect architecture if not provided
+    if arch is None:
+        arch = os.getenv(HAILO_ARCH_KEY) or detect_hailo_arch()
+        if not arch:
+            arch = HAILO8_ARCH
+    
+    print(f"\n{'=' * 60}")
+    print(f"Available models for: {app_name} ({arch})")
+    print(f"{'=' * 60}")
+    
+    # Check if architecture is supported
+    supported_archs = get_supported_architectures_for_app(app_name)
+    if arch not in supported_archs:
+        if is_gen_ai_app(app_name):
+            print(f"\n⚠️  This is a Gen-AI app, only available on: {', '.join(supported_archs)}")
+        else:
+            print(f"\n⚠️  Architecture '{arch}' not supported. Available: {', '.join(supported_archs)}")
+        print()
+        sys.exit(0)
+    
+    # Get models
+    default_models = get_default_models_for_app_and_arch(app_name, arch)
+    extra_models = get_extra_models_for_app_and_arch(app_name, arch)
+    
+    if default_models:
+        print("\n📦 Default Models:")
+        for model in default_models:
+            print(f"   • {model}")
+    else:
+        print("\n📦 Default Models: None")
+    
+    if extra_models:
+        print("\n📚 Extra Models:")
+        for model in extra_models:
+            print(f"   • {model}")
+    
+    print(f"\n{'=' * 60}")
+    print(f"Total: {len(default_models)} default, {len(extra_models)} extra")
+    print("\nUsage: --hef-path <model_name>")
+    print("       Model will be auto-downloaded if not found locally.")
+    print()
+    sys.exit(0)
+
+
+def resolve_hef_path(
+    hef_path: str | None,
+    app_name: str,
+    arch: str
+) -> Path | None:
+    """
+    Smart HEF path resolution with auto-download capability.
+    
+    Resolution order:
+    1. If hef_path is None, use default model for the app
+    2. If hef_path is a full path that exists, use it
+    3. If hef_path is in the resources folder, use it
+    4. If hef_path is a known model name, download it
+    
+    Args:
+        hef_path: User-provided path or model name (can be None)
+        app_name: App name from resources config (e.g., 'detection') - use pipeline constants like DETECTION_PIPELINE
+        arch: Hailo architecture
+    
+    Returns:
+        Resolved Path to the HEF file, or None if not found
+    """
+    try:
+        from hailo_apps.installation.config_utils import (
+            get_all_models_for_app_and_arch,
+            get_default_model_for_app_and_arch,
+        )
+    except ImportError:
+        hailo_logger.warning("Could not import config_utils, using legacy resolution")
+        # Fallback to legacy resolution
+        if hef_path is None:
+            return get_resource_path(app_name, RESOURCES_MODELS_DIR_NAME, arch)
+        return Path(hef_path) if hef_path else None
+    
+    resources_root = Path(RESOURCES_ROOT_PATH_DEFAULT)
+    models_dir = resources_root / RESOURCES_MODELS_DIR_NAME / arch
+    
+    # Get available models for this app/arch
+    available_models = get_all_models_for_app_and_arch(app_name, arch)
+    default_model = get_default_model_for_app_and_arch(app_name, arch)
+    is_using_default = False
+    
+    # Case 1: No hef_path provided - use default model
+    if hef_path is None:
+        if default_model:
+            hef_path = default_model
+            is_using_default = True
+            hailo_logger.info(f"Using default model: {default_model}")
+        else:
+            # Fallback to legacy pipeline-based model
+            legacy_path = get_resource_path(app_name, RESOURCES_MODELS_DIR_NAME, arch)
+            if legacy_path and legacy_path.exists():
+                return legacy_path
+            hailo_logger.error(f"No default model found for {app_name}/{arch}")
+            return None
+    
+    # Normalize model name (remove .hef if present)
+    model_name = hef_path
+    if model_name.endswith(HAILO_FILE_EXTENSION):
+        model_name = model_name[:-len(HAILO_FILE_EXTENSION)]
+    
+    # Case 2: Check if it's a full path that exists
+    hef_full_path = Path(hef_path)
+    if hef_full_path.is_absolute() and hef_full_path.exists():
+        hailo_logger.info(f"Using HEF from absolute path: {hef_full_path}")
+        return hef_full_path
+    
+    # Also check with .hef extension
+    if not hef_path.endswith(HAILO_FILE_EXTENSION):
+        hef_full_path = Path(hef_path + HAILO_FILE_EXTENSION)
+        if hef_full_path.exists():
+            hailo_logger.info(f"Using HEF from path: {hef_full_path}")
+            return hef_full_path
+    
+    # Case 3: Check in resources folder
+    resource_path = models_dir / f"{model_name}{HAILO_FILE_EXTENSION}"
+    if resource_path.exists():
+        hailo_logger.info(f"Found HEF in resources: {resource_path}")
+        return resource_path
+    
+    # Case 4: Model not found locally - check if it's in the available models list
+    if model_name in available_models:
+        # Show warning before downloading
+        if is_using_default:
+            print(f"\n⚠️  WARNING: Default model '{model_name}' is not downloaded.")
+            print(f"   Downloading model for {app_name}/{arch}...")
+            print(f"   This may take a while depending on your internet connection.\n")
+        else:
+            print(f"\n⚠️  WARNING: Model '{model_name}' is not downloaded.")
+            print(f"   Downloading model for {app_name}/{arch}...")
+            print(f"   This may take a while depending on your internet connection.\n")
+        
+        if _download_model(model_name, arch):
+            if resource_path.exists():
+                hailo_logger.info(f"Model downloaded successfully: {resource_path}")
+                return resource_path
+            else:
+                hailo_logger.error(f"Download succeeded but file not found: {resource_path}")
+                return None
+        else:
+            hailo_logger.error(f"Failed to download model: {model_name}")
+            return None
+    
+    # Model not in available list - don't auto-download unknown models
+    hailo_logger.error(
+        f"Model '{model_name}' not found and not in available models list. "
+        f"Available models for {app_name}/{arch}: {', '.join(available_models) if available_models else 'None'}"
+    )
+    return None
+
+
+def _download_model(model_name: str, arch: str) -> bool:
+    """
+    Download a specific model using the download_resources module.
+    
+    Args:
+        model_name: Name of the model to download
+        arch: Hailo architecture
+    
+    Returns:
+        True if download succeeded, False otherwise
+    """
+    try:
+        from hailo_apps.installation.download_resources import download_resources
+        
+        print(f"Downloading model: {model_name} for {arch}...")
+        download_resources(
+            arch=arch,
+            model=model_name,
+            dry_run=False,
+            force=False,
+            parallel=False  # Sequential for single model
+        )
+        return True
+    except Exception as e:
+        hailo_logger.error(f"Failed to download model: {e}")
+        return False
+
+
+def handle_list_models_flag(args, app_name: str) -> None:
+    """
+    Handle the --list-models flag if present.
+    
+    Args:
+        args: Parsed arguments (or parser to parse)
+        app_name: App name from resources config
+    """
+    # Parse args if it's a parser
+    if hasattr(args, 'parse_known_args'):
+        options, _ = args.parse_known_args()
+    else:
+        options = args
+    
+    # Check if --list-models flag is set
+    if getattr(options, 'list_models', False):
+        arch = getattr(options, 'arch', None)
+        list_models_for_app(app_name, arch)

--- a/hailo_apps/python/core/common/core.py
+++ b/hailo_apps/python/core/common/core.py
@@ -1,4 +1,4 @@
-"""Core helpers: arch detection, parser, buffer utils, model resolution."""
+"""Core helpers: arch detection, parser, buffer utils."""
 
 import argparse
 import os
@@ -306,6 +306,17 @@ def get_pipeline_parser():
             "rebuilt. Note: This requires the application callback to be enabled (i.e., not disabled via --disable-callback)."
         )
     )
+ 
+    parser.add_argument(
+        "--get-gst-launch",
+        action="store_true",
+        help=(
+            "Print the GStreamer pipeline string and exit. "
+            "When enabled, the application will print the full gst-launch-1.0 command that represents "
+            "the pipeline configuration and then exit. This is useful for debugging or running "
+            "the pipeline directly from the command line."
+        )
+    )
 
     return parser
 
@@ -464,229 +475,3 @@ class FIFODropQueue(queue.Queue):
             hailo_logger.debug("Queue full, dropping oldest item.")
             self.get_nowait()
         super().put(item, block, timeout)
-
-
-# =============================================================================
-# Model Resolution and Listing
-# =============================================================================
-
-def list_models_for_app(app_name: str, arch: str | None = None) -> None:
-    """
-    List all available models for an application and exit.
-    
-    Args:
-        app_name: The app name from resources config (e.g., 'detection', 'vlm_chat')
-        arch: Hailo architecture. If None, auto-detects.
-    """
-    try:
-        from hailo_apps.installation.config_utils import (
-            get_default_models_for_app_and_arch,
-            get_extra_models_for_app_and_arch,
-            get_supported_architectures_for_app,
-            is_gen_ai_app,
-        )
-    except ImportError:
-        print("Error: Could not import config_utils. Run 'pip install -e .' first.")
-        sys.exit(1)
-    
-    # Detect architecture if not provided
-    if arch is None:
-        arch = os.getenv(HAILO_ARCH_KEY) or detect_hailo_arch()
-        if not arch:
-            arch = HAILO8_ARCH
-    
-    print(f"\n{'=' * 60}")
-    print(f"Available models for: {app_name} ({arch})")
-    print(f"{'=' * 60}")
-    
-    # Check if architecture is supported
-    supported_archs = get_supported_architectures_for_app(app_name)
-    if arch not in supported_archs:
-        if is_gen_ai_app(app_name):
-            print(f"\n⚠️  This is a Gen-AI app, only available on: {', '.join(supported_archs)}")
-        else:
-            print(f"\n⚠️  Architecture '{arch}' not supported. Available: {', '.join(supported_archs)}")
-        print()
-        sys.exit(0)
-    
-    # Get models
-    default_models = get_default_models_for_app_and_arch(app_name, arch)
-    extra_models = get_extra_models_for_app_and_arch(app_name, arch)
-    
-    if default_models:
-        print("\n📦 Default Models:")
-        for model in default_models:
-            print(f"   • {model}")
-    else:
-        print("\n📦 Default Models: None")
-    
-    if extra_models:
-        print("\n📚 Extra Models:")
-        for model in extra_models:
-            print(f"   • {model}")
-    
-    print(f"\n{'=' * 60}")
-    print(f"Total: {len(default_models)} default, {len(extra_models)} extra")
-    print("\nUsage: --hef-path <model_name>")
-    print("       Model will be auto-downloaded if not found locally.")
-    print()
-    sys.exit(0)
-
-
-def resolve_hef_path(
-    hef_path: str | None,
-    app_name: str,
-    arch: str
-) -> Path | None:
-    """
-    Smart HEF path resolution with auto-download capability.
-    
-    Resolution order:
-    1. If hef_path is None, use default model for the app
-    2. If hef_path is a full path that exists, use it
-    3. If hef_path is in the resources folder, use it
-    4. If hef_path is a known model name, download it
-    
-    Args:
-        hef_path: User-provided path or model name (can be None)
-        app_name: App name from resources config (e.g., 'detection') - use pipeline constants like DETECTION_PIPELINE
-        arch: Hailo architecture
-    
-    Returns:
-        Resolved Path to the HEF file, or None if not found
-    """
-    try:
-        from hailo_apps.installation.config_utils import (
-            get_all_models_for_app_and_arch,
-            get_default_model_for_app_and_arch,
-        )
-    except ImportError:
-        hailo_logger.warning("Could not import config_utils, using legacy resolution")
-        # Fallback to legacy resolution
-        if hef_path is None:
-            return get_resource_path(app_name, RESOURCES_MODELS_DIR_NAME, arch)
-        return Path(hef_path) if hef_path else None
-    
-    resources_root = Path(RESOURCES_ROOT_PATH_DEFAULT)
-    models_dir = resources_root / RESOURCES_MODELS_DIR_NAME / arch
-    
-    # Get available models for this app/arch
-    available_models = get_all_models_for_app_and_arch(app_name, arch)
-    default_model = get_default_model_for_app_and_arch(app_name, arch)
-    is_using_default = False
-    
-    # Case 1: No hef_path provided - use default model
-    if hef_path is None:
-        if default_model:
-            hef_path = default_model
-            is_using_default = True
-            hailo_logger.info(f"Using default model: {default_model}")
-        else:
-            # Fallback to legacy pipeline-based model
-            legacy_path = get_resource_path(app_name, RESOURCES_MODELS_DIR_NAME, arch)
-            if legacy_path and legacy_path.exists():
-                return legacy_path
-            hailo_logger.error(f"No default model found for {app_name}/{arch}")
-            return None
-    
-    # Normalize model name (remove .hef if present)
-    model_name = hef_path
-    if model_name.endswith(HAILO_FILE_EXTENSION):
-        model_name = model_name[:-len(HAILO_FILE_EXTENSION)]
-    
-    # Case 2: Check if it's a full path that exists
-    hef_full_path = Path(hef_path)
-    if hef_full_path.is_absolute() and hef_full_path.exists():
-        hailo_logger.info(f"Using HEF from absolute path: {hef_full_path}")
-        return hef_full_path
-    
-    # Also check with .hef extension
-    if not hef_path.endswith(HAILO_FILE_EXTENSION):
-        hef_full_path = Path(hef_path + HAILO_FILE_EXTENSION)
-        if hef_full_path.exists():
-            hailo_logger.info(f"Using HEF from path: {hef_full_path}")
-            return hef_full_path
-    
-    # Case 3: Check in resources folder
-    resource_path = models_dir / f"{model_name}{HAILO_FILE_EXTENSION}"
-    if resource_path.exists():
-        hailo_logger.info(f"Found HEF in resources: {resource_path}")
-        return resource_path
-    
-    # Case 4: Model not found locally - check if it's in the available models list
-    if model_name in available_models:
-        # Show warning before downloading
-        if is_using_default:
-            print(f"\n⚠️  WARNING: Default model '{model_name}' is not downloaded.")
-            print(f"   Downloading model for {app_name}/{arch}...")
-            print(f"   This may take a while depending on your internet connection.\n")
-        else:
-            print(f"\n⚠️  WARNING: Model '{model_name}' is not downloaded.")
-            print(f"   Downloading model for {app_name}/{arch}...")
-            print(f"   This may take a while depending on your internet connection.\n")
-        
-        if _download_model(model_name, arch):
-            if resource_path.exists():
-                hailo_logger.info(f"Model downloaded successfully: {resource_path}")
-                return resource_path
-            else:
-                hailo_logger.error(f"Download succeeded but file not found: {resource_path}")
-                return None
-        else:
-            hailo_logger.error(f"Failed to download model: {model_name}")
-            return None
-    
-    # Model not in available list - don't auto-download unknown models
-    hailo_logger.error(
-        f"Model '{model_name}' not found and not in available models list. "
-        f"Available models for {app_name}/{arch}: {', '.join(available_models) if available_models else 'None'}"
-    )
-    return None
-
-
-def _download_model(model_name: str, arch: str) -> bool:
-    """
-    Download a specific model using the download_resources module.
-    
-    Args:
-        model_name: Name of the model to download
-        arch: Hailo architecture
-    
-    Returns:
-        True if download succeeded, False otherwise
-    """
-    try:
-        from hailo_apps.installation.download_resources import download_resources
-        
-        print(f"Downloading model: {model_name} for {arch}...")
-        download_resources(
-            arch=arch,
-            model=model_name,
-            dry_run=False,
-            force=False,
-            parallel=False  # Sequential for single model
-        )
-        return True
-    except Exception as e:
-        hailo_logger.error(f"Failed to download model: {e}")
-        return False
-
-
-def handle_list_models_flag(args, app_name: str) -> None:
-    """
-    Handle the --list-models flag if present.
-    
-    Args:
-        args: Parsed arguments (or parser to parse)
-        app_name: App name from resources config
-    """
-    # Parse args if it's a parser
-    if hasattr(args, 'parse_known_args'):
-        options, _ = args.parse_known_args()
-    else:
-        options = args
-    
-    # Check if --list-models flag is set
-    if getattr(options, 'list_models', False):
-        arch = getattr(options, 'arch', None)
-        list_models_for_app(app_name, arch)

--- a/hailo_apps/python/core/common/defines.py
+++ b/hailo_apps/python/core/common/defines.py
@@ -112,6 +112,7 @@ RESOURCES_PATH_KEY = "resources_path"
 VIRTUAL_ENV_NAME_KEY = "virtual_env_name"
 TAPPAS_POSTPROC_PATH_KEY = "tappas_postproc_path"
 HAILO_APPS_INFRA_PATH_KEY = "hailo_apps_infra_path"
+LOG_LEVEL_KEY = "log_level"
 
 # Environment variable groups
 DIC_CONFIG_VARIANTS = [
@@ -278,7 +279,7 @@ CLIP_CROPPER_OBJECT_POSTPROCESS_FUNCTION_NAME = 'object_cropper'
 CLIP_DETECTOR_TYPE_PERSON = 'person'
 CLIP_DETECTOR_TYPE_VEHICLE = 'vehicle'
 CLIP_DETECTOR_TYPE_FACE = 'face'
-CLIP_DETECTOR_TYPE_LICENSE_PLATE = 'license-plate'  
+CLIP_DETECTOR_TYPE_LICENSE_PLATE = 'license-plate'
 
 # Multisource pipeline defaults
 MULTI_SOURCE_APP_TITLE = "Hailo Multisource App"

--- a/hailo_apps/python/core/common/hailo_logger.py
+++ b/hailo_apps/python/core/common/hailo_logger.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import uuid
+from pathlib import Path
 from datetime import datetime
 from typing import Any
 
@@ -58,7 +59,7 @@ def init_logging(
     Priority for level:
       1) explicit param
       2) env HAILO_LOG_LEVEL
-      3) env LOG_LEVEL
+      3) config.yaml
       4) INFO (default)
 
     If log_file is provided (or $HAILO_LOG_FILE is set),
@@ -72,8 +73,24 @@ def init_logging(
         return
 
     # Resolve level from param or env
-    env_level = os.getenv("HAILO_LOG_LEVEL") or os.getenv("LOG_LEVEL")
-    resolved_level = _coerce_level(level if level is not None else env_level)
+    env_level = os.getenv("HAILO_LOG_LEVEL")
+
+    config_level = None
+    if level is None and env_level is None:
+        try:
+            # Lazy import to avoid circular dependencies
+            from hailo_apps.installation.config_utils import load_config
+            from hailo_apps.python.core.common.defines import DEFAULT_CONFIG_PATH, LOG_LEVEL_KEY
+
+            if os.path.exists(DEFAULT_CONFIG_PATH):
+                cfg = load_config(Path(DEFAULT_CONFIG_PATH))
+                config_level = cfg.get(LOG_LEVEL_KEY)
+        except ImportError:
+            pass
+        except Exception:
+            pass
+
+    resolved_level = _coerce_level(level or env_level or config_level)
 
     # Clear existing handlers to avoid duplicates (tests/notebooks/CLI reuse)
     root = logging.getLogger()
@@ -188,9 +205,9 @@ def add_logging_cli_args(parser: Any) -> None:
     """
     parser.add_argument(
         "--log-level",
-        default=os.getenv("HAILO_LOG_LEVEL", "INFO"),
+        default=None,
         choices=[k.lower() for k in _LEVELS.keys()],
-        help="Logging level (default: %(default)s or $HAILO_LOG_LEVEL / $LOG_LEVEL).",
+        help="Logging level (default: INFO, or configured in config.yaml, or $HAILO_LOG_LEVEL).",
     )
     parser.add_argument(
         "--debug",
@@ -204,17 +221,18 @@ def add_logging_cli_args(parser: Any) -> None:
     )
 
 
-def level_from_args(args: Any) -> str:
+def level_from_args(args: Any) -> str | None:
     """Resolve level string from argparse args."""
-    return (
-        "DEBUG"
-        if getattr(args, "debug", False)
-        else str(getattr(args, "log_level", "INFO")).upper()
-    )
+    if getattr(args, "debug", False):
+        return "DEBUG"
+
+    val = getattr(args, "log_level", None)
+    return str(val).upper() if val is not None else None
 
 
-# If someone forgets to init, default to simple INFO console logging.
-if os.getenv("HAILO_LOG_AUTOCONFIG", "1") == "1":
+# Auto-config is opt-in: set HAILO_LOG_AUTOCONFIG=1 to enable.
+# Useful for notebooks/REPL but applications should explicitly call init_logging().
+if os.getenv("HAILO_LOG_AUTOCONFIG", "0") == "1":
     try:
         init_logging()
     except Exception:

--- a/hailo_apps/python/core/common/test_utils.py
+++ b/hailo_apps/python/core/common/test_utils.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess
 import time
+import shlex
 
 import pytest
 from pathlib import Path
@@ -128,13 +129,52 @@ def run_pipeline_cli_with_args(cli: str, args: list[str], log_file: str, **kwarg
     return run_pipeline_generic([cli, *args], log_file, **kwargs)
 
 
+def run_pipeline_gst_launch_with_args(script: str, args: list[str], log_file: str, **kwargs):
+    """Run the pipeline using gst-launch-1.0 by first generating the pipeline string."""
+    # 1. Run with --get-gst-launch to get the pipeline string
+    cmd = ["python", "-u", script, *args, "--get-gst-launch"]
+
+    # We need to set PYTHONPATH for the generation step too
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "./hailo_apps_infra"
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+        output = proc.stdout
+    except subprocess.CalledProcessError as e:
+        with open(log_file, "w") as f:
+            f.write(f"Failed to get gst-launch command. Exit code: {e.returncode}\n")
+            f.write("stdout:\n" + e.stdout + "\n")
+            f.write("stderr:\n" + e.stderr + "\n")
+        return e.stdout.encode(), e.stderr.encode()
+
+    # 2. Extract gst-launch command
+    gst_cmd_str = ""
+    for line in output.splitlines():
+        if line.strip().startswith("gst-launch-1.0"):
+            gst_cmd_str = line.strip()
+            break
+
+    if not gst_cmd_str:
+        with open(log_file, "w") as f:
+            f.write("Failed to find gst-launch-1.0 command in output\n")
+            f.write("stdout:\n" + output + "\n")
+        return output.encode(), b"gst-launch command not found"
+
+    # 3. Run the extracted command
+    gst_cmd = shlex.split(gst_cmd_str)
+
+    # We use run_pipeline_generic to execute it
+    return run_pipeline_generic(gst_cmd, log_file, **kwargs)
+
+
 def safe_decode(data: bytes, errors: str = 'replace') -> str:
     """Safely decode bytes to string, handling encoding errors gracefully.
-    
+
     Args:
         data: Bytes to decode
         errors: Error handling strategy ('replace', 'ignore', or 'strict')
-    
+
     Returns:
         Decoded string, or empty string if decoding fails
     """
@@ -152,11 +192,11 @@ def safe_decode(data: bytes, errors: str = 'replace') -> str:
 
 def check_hailo8l_on_hailo8_warning(stdout: bytes, stderr: bytes) -> bool:
     """Check if the HailoRT warning about Hailo8L HEF on Hailo8 device is present.
-    
+
     Args:
         stdout: Standard output from the pipeline
         stderr: Standard error from the pipeline
-    
+
     Returns:
         bool: True if the warning is found, False otherwise
     """
@@ -175,13 +215,13 @@ def check_hailo8l_on_hailo8_warning(stdout: bytes, stderr: bytes) -> bool:
 
 def check_qos_performance_warning(stdout: bytes, stderr: bytes) -> tuple[bool, int]:
     """Check for QoS messages indicating performance issues.
-    
+
     Args:
         stdout: Standard output from the pipeline
         stderr: Standard error from the pipeline
-    
+
     Returns:
-        tuple: (has_warning, qos_count) where has_warning is True if QoS >= 100, 
+        tuple: (has_warning, qos_count) where has_warning is True if QoS >= 100,
                and qos_count is the number of QoS messages found
     """
     import re
@@ -193,15 +233,15 @@ def check_qos_performance_warning(stdout: bytes, stderr: bytes) -> tuple[bool, i
             output = (stdout.decode(errors='ignore') if stdout else "") + (stderr.decode(errors='ignore') if stderr else "")
         except Exception:
             return False, 0
-    
+
     # Look for "QoS messages: X total" pattern
     pattern = r"QoS messages:\s*(\d+)\s+total"
     matches = re.findall(pattern, output)
-    
+
     if matches:
         # Get the highest count found (in case there are multiple)
         qos_count = max(int(match) for match in matches)
         has_warning = qos_count >= 100
         return has_warning, qos_count
-    
+
     return False, 0

--- a/hailo_apps/python/core/gstreamer/gstreamer_app.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_app.py
@@ -437,6 +437,11 @@ class GStreamerApp:
         Gst.init(None)
         pipeline_string = self.get_pipeline_string()
         hailo_logger.debug(f"Pipeline string: {pipeline_string}")
+
+        if getattr(self.options_menu, "get_gst_launch", False):
+            print(f"\ngst-launch-1.0 {pipeline_string}")
+            sys.exit(0)
+
         try:
             self.pipeline = Gst.parse_launch(pipeline_string)
         except Exception as e:

--- a/hailo_apps/python/pipeline_apps/clip/README.md
+++ b/hailo_apps/python/pipeline_apps/clip/README.md
@@ -1,5 +1,6 @@
 # CLIP Application
 
+
 A real-time zero-shot image classification and object recognition application using OpenAI's CLIP model with Hailo AI acceleration.
 
 [![CLIP Application Demo](https://img.youtube.com/vi/XXizBHtCLew/0.jpg)](https://www.youtube.com/watch?v=XXizBHtCLew)
@@ -94,6 +95,8 @@ hailo-clip --input usb --json-path office_objects.json --detector none
 ```
 - Direct CLIP on USB camera feed
 - Uses custom object descriptions
+
+> **Note:** This application does not support the `--get-gst-launch` flag for CLI-only execution. CLIP functionality requires Python-based text-image matching, GUI interaction, and embedding calculations that cannot be replaced by GStreamer-only pipelines.
 
 ## How CLIP Works
 
@@ -257,12 +260,12 @@ The application includes example files:
 
 ### CLIP-Specific Options
 
-| Argument | Description | Default |
-|----------|-------------|---------|
-| `--detector, -d` | Detection mode: `person`, `face`, or `none` | `none` |
-| `--json-path` | Path to JSON embeddings file | `embeddings.json` or `example_embeddings.json` |
-| `--detection-threshold` | Similarity threshold for matching (0.0-1.0) | `0.5` |
-| `--disable-runtime-prompts` | Skip CLIP text encoder initialization | `False` |
+| Argument                    | Description                                 | Default                                        |
+| --------------------------- | ------------------------------------------- | ---------------------------------------------- |
+| `--detector, -d`            | Detection mode: `person`, `face`, or `none` | `none`                                         |
+| `--json-path`               | Path to JSON embeddings file                | `embeddings.json` or `example_embeddings.json` |
+| `--detection-threshold`     | Similarity threshold for matching (0.0-1.0) | `0.5`                                          |
+| `--disable-runtime-prompts` | Skip CLIP text encoder initialization       | `False`                                        |
 
 ### Common Pipeline Arguments
 
@@ -322,11 +325,11 @@ Pipeline elements are prioritized for optimal performance:
 
 ### Models Used
 
-| Component | Model | Input Size | Purpose |
-|-----------|-------|------------|---------|
-| Detection | YOLOv8n-personface | 480×640 | Person/face detection |
-| CLIP Image | CLIP ResNet-50x4 | 640×640 | Visual feature extraction |
-| CLIP Text | CLIP ResNet-50x4 Text | N/A | Text encoding (CPU) |
+| Component  | Model                 | Input Size | Purpose                   |
+| ---------- | --------------------- | ---------- | ------------------------- |
+| Detection  | YOLOv8n-personface    | 480×640    | Person/face detection     |
+| CLIP Image | CLIP ResNet-50x4      | 640×640    | Visual feature extraction |
+| CLIP Text  | CLIP ResNet-50x4 Text | N/A        | Text encoding (CPU)       |
 
 ### Post-Processing
 

--- a/hailo_apps/python/pipeline_apps/depth/depth_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/depth/depth_pipeline.py
@@ -154,5 +154,5 @@ def main():
 
 
 if __name__ == "__main__":
-    print("Starting Hailo Depth App...")
+    hailo_logger.info("Starting Hailo Depth App...")
     main()

--- a/hailo_apps/python/pipeline_apps/detection_simple/detection_simple_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/detection_simple/detection_simple_pipeline.py
@@ -145,7 +145,6 @@ class GStreamerDetectionSimpleApp(GStreamerApp):
             f"{user_callback_pipeline} ! "
             f"{display_pipeline}"
         )
-        hailo_logger.info(f"Pipeline string: {pipeline_string}")
         return pipeline_string
 
 

--- a/hailo_apps/python/pipeline_apps/face_recognition/README.md
+++ b/hailo_apps/python/pipeline_apps/face_recognition/README.md
@@ -93,6 +93,8 @@ Open the interface on: http://localhost:5151/ (When executed from an IDE such as
 
 Please refer to the https://voxel51.com/fiftyone/ guide for more details about using the interface.
 
+> **Note:** This application does not support the `--get-gst-launch` flag for CLI-only execution. Face recognition requires Python-based database operations and vector search that cannot be replaced by GStreamer-only pipelines.
+
 ---
 
 ## Telegram Notifications

--- a/hailo_apps/python/pipeline_apps/multisource/multisource_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/multisource/multisource_pipeline.py
@@ -80,7 +80,6 @@ class GStreamerMultisourceApp(GStreamerApp):
             inference_string += f"src_{id}::input-streams=\"<sink_{id}>\" "
 
         pipeline_string = sources_string + inference_string + router_string
-        print(pipeline_string)
         return pipeline_string
 
 def main():
@@ -91,5 +90,5 @@ def main():
     app.run()
 
 if __name__ == "__main__":
-    print("Starting Hailo Multisource App...")
+    hailo_logger.info("Starting Hailo Multisource App...")
     main()

--- a/hailo_apps/python/pipeline_apps/pose_estimation/pose_estimation_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/pose_estimation/pose_estimation_pipeline.py
@@ -120,7 +120,6 @@ class GStreamerPoseEstimationApp(GStreamerApp):
             f"{display_pipeline}"
         )
         hailo_logger.debug("Pipeline string: %s", pipeline_string)
-        print(pipeline_string)
         return pipeline_string
 
 

--- a/hailo_apps/python/pipeline_apps/reid_multisource/README.md
+++ b/hailo_apps/python/pipeline_apps/reid_multisource/README.md
@@ -21,7 +21,7 @@ The pipeline is rather complex, combining elements from multisource and face rec
 
 Similar to the face recognition application, dedicated networks assign unique embedding for each face, which is stored in LanceDB. Every detected face is first queried against the database for recognition.
 
-The available arguments are similar to the multisource application and include `--sources`, `--width` & `--height`, while `--frame-rate` is hardcoded to be 15 for optimization of performance. 
+The available arguments are similar to the multisource application and include `--sources`, `--width` & `--height`, while `--frame-rate` is hardcoded to be 15 for optimization of performance.
 
 Please note that the DB is populated persistently on each run, and will remember the faces. For a fresh start, simply delete the database files.
 
@@ -33,3 +33,5 @@ For additional options, execute:
 ```bash
 hailo-reid --help
 ```
+
+> **Note:** This application does not support the `--get-gst-launch` flag for CLI-only execution. Person re-identification requires Python-based cross-camera tracking database and vector matching logic that cannot be replaced by GStreamer-only pipelines.

--- a/hailo_apps/python/pipeline_apps/reid_multisource/reid_multisource_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/reid_multisource/reid_multisource_pipeline.py
@@ -255,5 +255,5 @@ def main():
     app.run()
 
 if __name__ == "__main__":
-    print("Starting Hailo REID Multisource App...")
+    hailo_logger.info("Starting Hailo REID Multisource App...")
     main()

--- a/hailo_apps/python/pipeline_apps/tiling/tiling_pipeline.py
+++ b/hailo_apps/python/pipeline_apps/tiling/tiling_pipeline.py
@@ -67,7 +67,7 @@ class GStreamerTilingApp(GStreamerApp):
         setproctitle.setproctitle(TILING_APP_TITLE)
 
         # Print configuration summary
-        self._print_configuration()
+	self._print_configuration()
 
         self.create_pipeline()
 
@@ -276,5 +276,5 @@ def main() -> None:
     app.run()
 
 if __name__ == "__main__":
-    print("Starting Hailo Tiling App...")
+    hailo_logger.info("Starting Hailo Tiling App...")
     main()

--- a/hailo_apps/python/standalone_apps/Examples/llm_chat.py
+++ b/hailo_apps/python/standalone_apps/Examples/llm_chat.py
@@ -4,16 +4,21 @@ from hailo_platform import VDevice
 from hailo_platform.genai import LLM
 from hailo_apps.python.core.common.core import get_resource_path, handle_list_models_flag, resolve_hef_path
 from hailo_apps.python.core.common.defines import LLM_CHAT_APP, LLM_MODEL_NAME_H10, RESOURCES_MODELS_DIR_NAME, SHARED_VDEVICE_GROUP_ID, HAILO10H_ARCH
+from hailo_apps.python.core.common.hailo_logger import add_logging_cli_args, init_logging, level_from_args
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="LLM Chat Example")
 parser.add_argument("--hef-path", type=str, default=None, help="Path to HEF model file")
 parser.add_argument("--list-models", action="store_true", help="List available models")
+add_logging_cli_args(parser)
 
 # Handle --list-models flag before full initialization
 handle_list_models_flag(parser, LLM_CHAT_APP)
 
 args = parser.parse_args()
+
+# Initialize logging
+init_logging(level=level_from_args(args))
 
 # Resolve HEF path with auto-download (LLM is Hailo-10H only)
 hef_path = resolve_hef_path(args.hef_path, app_name=LLM_CHAT_APP, arch=HAILO10H_ARCH)
@@ -31,18 +36,18 @@ try:
     params.group_id = SHARED_VDEVICE_GROUP_ID
     vdevice = VDevice(params)
     llm = LLM(vdevice, str(hef_path))
-    
+
     prompt = [
         {"role": "system", "content": [{"type": "text", "text": 'You are a helpful assistant.'}]},
         {"role": "user", "content": [{"type": "text", "text": 'Tell a short joke.'}]}
     ]
-    
+
     response = llm.generate_all(prompt=prompt, temperature=0.1, seed=42, max_generated_tokens=200)
     print(response.split(". [{'type'")[0])
-    
+
 except Exception as e:
     print(f"Error occurred: {e}")
-    
+
 finally:
     if llm:
         try:
@@ -50,7 +55,7 @@ finally:
             llm.release()
         except Exception as e:
             print(f"Error releasing LLM: {e}")
-    
+
     if vdevice:
         try:
             vdevice.release()

--- a/hailo_apps/python/standalone_apps/Examples/whisper_chat.py
+++ b/hailo_apps/python/standalone_apps/Examples/whisper_chat.py
@@ -1,14 +1,14 @@
-import argparse
 import sys
 import wave
 import numpy as np
 from hailo_platform import VDevice
 from hailo_platform.genai import Speech2Text, Speech2TextTask
-from hailo_apps.python.core.common.core import get_resource_path, handle_list_models_flag, resolve_hef_path
-from hailo_apps.python.core.common.defines import WHISPER_CHAT_APP, RESOURCES_MODELS_DIR_NAME, WHISPER_MODEL_NAME_H10, SHARED_VDEVICE_GROUP_ID, HAILO10H_ARCH
+from hailo_apps.python.core.common.core import get_standalone_parser, handle_list_models_flag, resolve_hef_path
+from hailo_apps.python.core.common.defines import WHISPER_CHAT_APP, SHARED_VDEVICE_GROUP_ID, HAILO10H_ARCH
+from hailo_apps.python.core.common.hailo_logger import init_logging, level_from_args
 
 # Parse arguments
-parser = argparse.ArgumentParser(description="Whisper Speech-to-Text Example")
+parser = get_standalone_parser()
 parser.add_argument("--hef-path", type=str, default=None, help="Path to HEF model file")
 parser.add_argument("--list-models", action="store_true", help="List available models")
 parser.add_argument("--audio", type=str, default="audio.wav", help="Path to audio file")
@@ -17,6 +17,9 @@ parser.add_argument("--audio", type=str, default="audio.wav", help="Path to audi
 handle_list_models_flag(parser, WHISPER_CHAT_APP)
 
 args = parser.parse_args()
+
+# Initialize logging
+init_logging(level=level_from_args(args))
 
 # Resolve HEF path with auto-download (Whisper is Hailo-10H only)
 hef_path = resolve_hef_path(args.hef_path, app_name=WHISPER_CHAT_APP, arch=HAILO10H_ARCH)
@@ -37,7 +40,7 @@ try:
 
     # Load audio file using wave module instead of librosa
     audio_path = args.audio
-    
+
     with wave.open(audio_path, 'rb') as wav_file:
         # Get audio parameters
         frames = wav_file.getnframes()
@@ -46,35 +49,35 @@ try:
         sample_width = wav_file.getsampwidth()
         # Read raw audio data
         raw_audio = wav_file.readframes(frames)
-    
+
     # Convert to numpy array based on sample width
     audio_data = np.frombuffer(raw_audio, dtype=np.int16)
     # Convert 16-bit to float32 and normalize
     audio_data = audio_data.astype(np.float32) / 32768.0
     # Ensure little-endian format as expected by the model
     audio_data = audio_data.astype('<f4')
-    
+
     # Create generator parameters and generate segments
     segments = speech2text.generate_all_segments(
-        audio_data=audio_data, 
+        audio_data=audio_data,
         task=Speech2TextTask.TRANSCRIBE,
         language="en",
         timeout_ms=15000)
-    
+
     if segments and len(segments) > 0:
         # Combine all segments into a single transcription
         transcription = ''.join([seg.text for seg in segments])
         print(transcription.strip())
     else:
         print("No transcription generated")
-    
+
 except FileNotFoundError as e:
     print(f"Audio file not found: {e}")
 except wave.Error as e:
     print(f"Error reading WAV file: {e}")
 except Exception as e:
     print(f"Error occurred: {e}")
-    
+
 finally:
     # Clean up resources
     if speech2text:
@@ -82,7 +85,7 @@ finally:
             speech2text.release()
         except Exception as e:
             print(f"Error releasing Speech2Text: {e}")
-    
+
     if vdevice:
         try:
             vdevice.release()

--- a/hailo_apps/python/standalone_apps/agent_tools_example/AGENTS.md
+++ b/hailo_apps/python/standalone_apps/agent_tools_example/AGENTS.md
@@ -200,8 +200,8 @@ The tool will be automatically discovered when you run `chat_agent.py`. No code 
 # Basic usage
 python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent
 
-# With debug logging (edit config.py: DEFAULT_LOG_LEVEL = "DEBUG")
-python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent
+# With debug logging (use --debug flag)
+python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent --debug
 
 # With custom model
 HAILO_HEF_PATH=/path/to/model.hef python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent
@@ -255,7 +255,7 @@ The voice chat agent:
 
 1. **Check tool description**: Ensure it clearly instructs when to use the tool
 2. **Check system prompt**: Should be simple and general
-3. **Enable debug logging**: Set `DEFAULT_LOG_LEVEL = "DEBUG"` in `config.py` to see full LLM responses
+3. **Enable debug logging**: Use `--debug` flag or set `HAILO_LOG_LEVEL=DEBUG` to see full LLM responses
 4. **Verify tool schema**: Ensure parameters are clearly described
 5. **Check function name**: Ensure description explicitly states the function name
 
@@ -275,7 +275,7 @@ The voice chat agent:
 When a tool isn't working as expected, follow this process:
 
 1.  **Enable Debug Logging**:
-    Set `DEFAULT_LOG_LEVEL = "DEBUG"` in `config.py` or use `--debug` flag.
+    Use `--debug` flag or set `HAILO_LOG_LEVEL=DEBUG`.
     This reveals:
     - The raw system prompt being sent
     - The raw LLM response (including XML tags)

--- a/hailo_apps/python/standalone_apps/agent_tools_example/README.md
+++ b/hailo_apps/python/standalone_apps/agent_tools_example/README.md
@@ -24,9 +24,14 @@ python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent
 
 ### With Debug Logging
 
-To enable debug logging, edit `config.py` and set:
-```python
-DEFAULT_LOG_LEVEL = "DEBUG"
+To enable debug logging, use the `--debug` flag:
+```bash
+python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent --debug
+```
+
+Or set the environment variable:
+```bash
+HAILO_LOG_LEVEL=DEBUG python -m hailo_apps.python.standalone_apps.agent_tools_example.chat_agent
 ```
 
 ## Interactive Commands

--- a/hailo_apps/python/standalone_apps/agent_tools_example/chat_agent.py
+++ b/hailo_apps/python/standalone_apps/agent_tools_example/chat_agent.py
@@ -29,6 +29,7 @@ from hailo_platform.genai import LLM
 
 from hailo_apps.python.core.common.core import handle_list_models_flag
 from hailo_apps.python.core.common.defines import AGENT_APP
+from hailo_apps.python.core.common.hailo_logger import add_logging_cli_args, init_logging, level_from_args
 
 from hailo_apps.python.core.gen_ai_utils.llm_utils import (
     agent_utils,
@@ -59,14 +60,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Chat Agent with Tool Calling")
     parser.add_argument("--hef-path", type=str, default=None, help="Path to HEF model file")
     parser.add_argument("--list-models", action="store_true", help="List available models")
-    
+    add_logging_cli_args(parser)
+
     # Handle --list-models flag before full initialization
     handle_list_models_flag(parser, AGENT_APP)
-    
+
     args = parser.parse_args()
-    
-    # Set up logging level from environment variable
-    config.setup_logging()
+
+    # Initialize logging
+    init_logging(level=level_from_args(args))
 
     # Validate configuration
     try:
@@ -208,7 +210,7 @@ def main() -> None:
 
             try:
                 # Use generate() for streaming output with on-the-fly filtering
-                is_debug = logger.level == logging.DEBUG
+                is_debug = logger.isEnabledFor(logging.DEBUG)
                 raw_response = streaming.generate_and_stream_response(
                     llm=llm,
                     prompt=prompt,

--- a/hailo_apps/python/standalone_apps/agent_tools_example/config.py
+++ b/hailo_apps/python/standalone_apps/agent_tools_example/config.py
@@ -29,12 +29,6 @@ CONTEXT_THRESHOLD: float = 0.95  # Clear context when usage reaches this percent
 # To use a different model, change DEFAULT_LLM_MODEL_NAME or set HAILO_HEF_PATH environment variable.
 DEFAULT_LLM_MODEL_NAME: str = LLM_CODER_MODEL_NAME_H10
 
-# Logging Configuration
-# Default log level (DEBUG, INFO, WARNING, ERROR)
-# - DEBUG: Shows all data passed between agent and tools (prompts, responses, tool calls/results)
-# - INFO (default): Shows only tool call indications
-DEFAULT_LOG_LEVEL: str = "INFO"
-
 # Hardware Configuration
 HARDWARE_MODE: str = "simulator"  # "real" or "simulator"
 # SPI configuration for NeoPixel (Raspberry Pi 5)
@@ -55,11 +49,6 @@ ENABLE_TTS: bool = True
 
 # Logger Setup
 LOGGER: logging.Logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s: %(message)s",
-    datefmt="%H:%M:%S",
-)
 
 
 def validate_config() -> None:
@@ -97,39 +86,6 @@ def validate_config() -> None:
         raise ValueError(f"Invalid CONTEXT_THRESHOLD {CONTEXT_THRESHOLD}. Must be between 0.1 and 1.0.")
 
 
-def setup_logging() -> None:
-    """
-    Set up logging level from configuration.
-
-    Creates a custom handler with a simple format for cleaner output,
-    while preserving the framework's detailed logging for other components.
-    """
-    log_level_str = DEFAULT_LOG_LEVEL.upper()
-    log_level = getattr(logging, log_level_str, logging.INFO)
-    LOGGER.setLevel(log_level)
-    # Also set root logger to ensure messages are shown
-    logging.root.setLevel(log_level)
-
-    # Add a custom handler with simple format for our logger
-    # This gives us clean output without interfering with framework logging
-    # agent_utils also uses this same logger, so it will get the same format
-
-    # Simple format: just level and message
-    simple_formatter = logging.Formatter("%(levelname)s: %(message)s")
-
-    if not any(isinstance(h, logging.StreamHandler) and getattr(h, '_chat_agent_handler', False)
-               for h in LOGGER.handlers):
-        simple_handler = logging.StreamHandler(sys.stdout)
-        simple_handler._chat_agent_handler = True  # type: ignore # Mark as our custom handler
-        simple_handler.setFormatter(simple_formatter)
-        simple_handler.setLevel(log_level)
-        LOGGER.addHandler(simple_handler)
-        # Prevent propagation to root logger to avoid duplicate messages
-        LOGGER.propagate = False
-
-    print(f"Logging level set to {log_level_str}")
-
-
 def get_hef_path(hef_path_arg: str | None = None) -> str:
     """
     Get HEF path from configuration with auto-download support.
@@ -159,7 +115,7 @@ def get_hef_path(hef_path_arg: str | None = None) -> str:
     custom_path = os.environ.get("HAILO_HEF_PATH")
     if custom_path:
         return custom_path
-    
+
     # Check if user provided a path via argument
     if hef_path_arg:
         custom_path = hef_path_arg

--- a/hailo_apps/python/standalone_apps/agent_tools_example/voice_chat_agent.py
+++ b/hailo_apps/python/standalone_apps/agent_tools_example/voice_chat_agent.py
@@ -35,6 +35,7 @@ from hailo_apps.python.core.gen_ai_utils.llm_utils import (
 )
 from hailo_apps.python.core.common.defines import SHARED_VDEVICE_GROUP_ID, AGENT_APP
 from hailo_apps.python.core.common.core import handle_list_models_flag
+from hailo_apps.python.core.common.hailo_logger import add_logging_cli_args, init_logging, level_from_args
 
 try:
     from . import config, system_prompt
@@ -209,7 +210,7 @@ class VoiceAgentApp:
 
         try:
             # Use generate() for streaming output with on-the-fly filtering and TTS callback
-            is_debug = logger.level == logging.DEBUG
+            is_debug = logger.isEnabledFor(logging.DEBUG)
             raw_response = streaming.generate_and_stream_response(
                 llm=self.llm,
                 prompt=prompt,
@@ -265,26 +266,24 @@ class VoiceAgentApp:
 
 
 def main():
-    config.setup_logging()
-
-    # Validate configuration
-    try:
-        config.validate_config()
-    except ValueError as e:
-        print(f"[Configuration Error] {e}")
-        return
-
     parser = argparse.ArgumentParser(description='Voice-enabled AI Tool Agent')
     parser.add_argument('--hef-path', type=str, default=None, help='Path to HEF model file')
     parser.add_argument('--list-models', action='store_true', help='List available models')
     parser.add_argument('--arch', type=str, default='hailo10h', help='Hailo architecture')
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--no-tts', action='store_true', help='Disable TTS')
-    
+    add_logging_cli_args(parser)
+
     # Handle --list-models flag before full initialization
     handle_list_models_flag(parser, AGENT_APP)
-    
+
     args = parser.parse_args()
+
+    # Initialize logging
+    init_logging(level=level_from_args(args))
+
+    # Validate configuration
+    try:
+        config.validate_config()
 
     # Get HEF (with auto-download support)
     try:

--- a/hailo_apps/python/standalone_apps/vlm_chat/vlm_chat.py
+++ b/hailo_apps/python/standalone_apps/vlm_chat/vlm_chat.py
@@ -10,13 +10,12 @@ from typing import Optional, Callable, Any
 
 os.environ["QT_QPA_PLATFORM"] = 'xcb'
 from backend import Backend
-from hailo_apps.python.core.common.core import get_default_parser, get_resource_path, get_logger, handle_list_models_flag, resolve_hef_path
+from hailo_apps.python.core.common.core import get_standalone_parser, get_logger, handle_list_models_flag, resolve_hef_path
+from hailo_apps.python.core.common.hailo_logger import init_logging, level_from_args
 from hailo_apps.python.core.common.camera_utils import get_usb_video_devices
 from hailo_apps.python.core.gstreamer.gstreamer_helper_pipelines import get_source_type
 from hailo_apps.python.core.common.defines import (
     VLM_CHAT_APP,
-    VLM_MODEL_NAME_H10,
-    RESOURCES_MODELS_DIR_NAME,
     HAILO10H_ARCH,
     RPI_NAME_I,
     USB_CAMERA
@@ -279,12 +278,15 @@ class VLMChatApp:
             self.video_thread.join()
 
 if __name__ == "__main__":
-    parser = get_default_parser()
-    
+    parser = get_standalone_parser()
+
     # Handle --list-models flag before full initialization
     handle_list_models_flag(parser, VLM_CHAT_APP)
-    
+
     options_menu = parser.parse_args()
+
+    # Initialize logging
+    init_logging(level=level_from_args(options_menu))
 
     # Resolve HEF path with auto-download (VLM is Hailo-10H only)
     hef_path = resolve_hef_path(
@@ -295,7 +297,7 @@ if __name__ == "__main__":
     if hef_path is None:
         logger.error("Failed to resolve HEF path for VLM model. Exiting.")
         sys.exit(1)
-    
+
     video_source = options_menu.input
     if video_source == USB_CAMERA:
         logger.debug("USB_CAMERA detected; scanning USB devices...")

--- a/hailo_apps/python/standalone_apps/voice_assistant/voice_assistant.py
+++ b/hailo_apps/python/standalone_apps/voice_assistant/voice_assistant.py
@@ -7,11 +7,12 @@ from hailo_platform import VDevice
 from hailo_platform.genai import LLM
 
 from hailo_apps.python.core.common.defines import LLM_PROMPT_PREFIX, SHARED_VDEVICE_GROUP_ID, RESOURCES_MODELS_DIR_NAME, LLM_MODEL_NAME_H10
-from hailo_apps.python.core.common.core import get_resource_path
+from hailo_apps.python.core.common.core import get_resource_path, get_standalone_parser
 from hailo_apps.python.core.gen_ai_utils.voice_processing.interaction import VoiceInteractionManager
 from hailo_apps.python.core.gen_ai_utils.voice_processing.speech_to_text import SpeechToTextProcessor
 from hailo_apps.python.core.gen_ai_utils.voice_processing.text_to_speech import TextToSpeechProcessor
 from hailo_apps.python.core.gen_ai_utils.llm_utils import streaming
+from hailo_apps.python.core.common.hailo_logger import add_logging_cli_args, init_logging, level_from_args
 
 
 class VoiceAssistantApp:
@@ -149,14 +150,16 @@ class VoiceAssistantApp:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='A simple, voice-controlled AI assistant for your terminal.')
-    parser.add_argument('--debug', action='store_true',
-                        help='Enable debug mode to save recorded audio files.')
+    parser = get_standalone_parser()
+    parser.description = 'A simple, voice-controlled AI assistant for your terminal.'
     parser.add_argument('--no-tts', action='store_true',
                         help='Disable text-to-speech output for lower resource usage.')
+    add_logging_cli_args(parser)
 
     args = parser.parse_args()
+
+    # Initialize logging
+    init_logging(level=level_from_args(args))
 
     if args.debug:
         print("Debug mode enabled: Audio will be saved to 'debug_audio_*.wav' files.")

--- a/tests/test_control.yaml
+++ b/tests/test_control.yaml
@@ -91,62 +91,62 @@ custom_tests:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
       description: "Object Detection Pipeline"
-    
+
     simple_detection:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
       description: "Simple Detection Pipeline"
-    
+
     face_recognition:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Face Recognition Pipeline"
-    
+
     instance_segmentation:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
       description: "Instance Segmentation Pipeline"
-    
+
     pose_estimation:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
       description: "Pose Estimation Pipeline"
-    
+
     depth:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
       description: "Depth Estimation Pipeline"
-    
+
     tiling:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Tiling Pipeline"
-    
+
     paddle_ocr:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Paddle OCR Pipeline"
-    
+
     clip:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "CLIP Pipeline"
-    
+
     retrain:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Retraining Pipeline"
-    
+
     lane_detection:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Lane Detection Pipeline"
-    
+
     super_resolution:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
       description: "Super Resolution Pipeline"
-    
+
     reid_multisource:
       test_suite_mode: "None"  # None | default | extra | all
       model_selection: "None"  # default | extra | all
@@ -157,15 +157,15 @@ special_tests:
   h8l_on_h8:
     enabled: true
     description: "Run H8L architecture on H8 hardware"
-  
+
   sanity_checks:
     enabled: true
     description: "Basic sanity checks before test execution"
-  
+
   human_verification:
     enabled: false
     description: "Tests requiring human verification and validation"
-  
+
   golden_tests:
     enabled: false
     description: "Golden reference tests for baseline validation"
@@ -175,14 +175,17 @@ run_methods:
   pythonpath:
     enabled: true  # Always true (primary method)
     priority: 1
-  
+
   cli:
     enabled: false
     priority: 2
     command_template: "python -m test_runner"
-  
+
   module:
     enabled: false
     priority: 3
     module_name: "test_execution.runner"
 
+  gst-launch:
+    enabled: true
+    priority: 4

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -66,18 +66,18 @@ def detect_and_set_environment():
     logger.info("=" * 80)
     logger.info("DETECTING SYSTEM ARCHITECTURE")
     logger.info("=" * 80)
-    
+
     host_arch = detect_host_arch()
     hailo_arch = detect_hailo_arch()
-    
+
     logger.info(f"Detected host architecture: {host_arch}")
     logger.info(f"Detected Hailo architecture: {hailo_arch or 'None (no device detected)'}")
-    
+
     # Set in current process environment
     os.environ["HOST_ARCH"] = host_arch
     if hailo_arch:
         os.environ["HAILO_ARCH"] = hailo_arch
-    
+
     logger.info("=" * 80)
     return host_arch, hailo_arch
 
@@ -86,14 +86,14 @@ def load_control_config() -> Dict:
     """Load test control configuration from test_control.yaml."""
     if not CONTROL_CONFIG_PATH.exists():
         pytest.fail(f"Test control configuration file not found: {CONTROL_CONFIG_PATH}")
-    
+
     logger.info(f"Loading control configuration from: {CONTROL_CONFIG_PATH}")
     with open(CONTROL_CONFIG_PATH, 'r') as f:
         config = yaml.safe_load(f)
-    
+
     if not config:
         pytest.fail("Failed to parse control configuration")
-    
+
     logger.info("✅ Control configuration loaded")
     return config
 
@@ -102,14 +102,14 @@ def load_definition_config() -> Dict:
     """Load test definition configuration from test_definition_config.yaml."""
     if not DEFINITION_CONFIG_PATH.exists():
         pytest.fail(f"Test definition configuration file not found: {DEFINITION_CONFIG_PATH}")
-    
+
     logger.info(f"Loading definition configuration from: {DEFINITION_CONFIG_PATH}")
     with open(DEFINITION_CONFIG_PATH, 'r') as f:
         config = yaml.safe_load(f)
-    
+
     if not config:
         pytest.fail("Failed to parse definition configuration")
-    
+
     logger.info("✅ Definition configuration loaded")
     return config
 
@@ -118,44 +118,44 @@ def load_resources_config() -> Dict:
     """Load resources configuration from resources_config.yaml."""
     if not RESOURCES_CONFIG_PATH.exists():
         pytest.fail(f"Resources configuration file not found: {RESOURCES_CONFIG_PATH}")
-    
+
     logger.info(f"Loading resources configuration from: {RESOURCES_CONFIG_PATH}")
     with open(RESOURCES_CONFIG_PATH, 'r') as f:
         config = yaml.safe_load(f)
-    
+
     if not config:
         pytest.fail("Failed to parse resources configuration")
-    
+
     logger.info("✅ Resources configuration loaded")
     return config
 
 
 def get_models_for_app_and_arch(resources_config: Dict, app_name: str, architecture: str, model_selection: str = "default") -> List[str]:
     """Get models for an app and architecture based on model_selection.
-    
+
     Args:
         resources_config: Resources configuration
         app_name: Application name
         architecture: Architecture (hailo8, hailo8l, hailo10h)
         model_selection: Model selection (default, extra, all)
-    
+
     Returns:
         List of model names
     """
     if app_name not in resources_config:
         logger.warning(f"App {app_name} not found in resources config")
         return []
-    
+
     app_config = resources_config[app_name]
     models_config = app_config.get("models", {})
-    
+
     if architecture not in models_config:
         logger.warning(f"Architecture {architecture} not found for app {app_name}")
         return []
-    
+
     arch_models = models_config[architecture]
     models = []
-    
+
     # Get default model if model_selection is "default" or "all"
     if model_selection in ["default", "all"]:
         if "default" in arch_models and arch_models["default"]:
@@ -164,7 +164,7 @@ def get_models_for_app_and_arch(resources_config: Dict, app_name: str, architect
                 models.append(default_model["name"])
             else:
                 models.append(default_model)
-    
+
     # Get extra models if model_selection is "extra" or "all"
     if model_selection in ["extra", "all"]:
         if "extra" in arch_models:
@@ -173,13 +173,13 @@ def get_models_for_app_and_arch(resources_config: Dict, app_name: str, architect
                     models.append(extra_model["name"])
                 else:
                     models.append(extra_model)
-    
+
     return models
 
 
 def resolve_test_suite_flags(definition_config: Dict, suite_name: str, resources_config: Dict, app_name: str, architecture: str, model: str) -> List[str]:
     """Resolve test suite flags with placeholders replaced.
-    
+
     Args:
         definition_config: Test definition configuration
         suite_name: Test suite name
@@ -187,27 +187,27 @@ def resolve_test_suite_flags(definition_config: Dict, suite_name: str, resources
         app_name: Application name
         architecture: Architecture
         model: Model name
-    
+
     Returns:
         List of resolved flags
     """
     test_suites = definition_config.get("test_suites", {})
     suite_config = test_suites.get(suite_name, {})
     flags = suite_config.get("flags", [])
-    
+
     # Resolve placeholders
     resources_root = RESOURCES_ROOT_PATH_DEFAULT
     hef_path = build_hef_path(model, architecture, resources_root)
-    
+
     # Get video path for app
     video_name = "example.mp4"  # default
     if app_name in resources_config:
         app_config = resources_config[app_name]
         # Try to get app-specific video from definition config resources
         # For now, use default
-    
+
     video_path = os.path.join(resources_root, "videos", video_name)
-    
+
     # Get labels JSON path if needed
     labels_json_path = None
     if app_name in resources_config:
@@ -222,7 +222,7 @@ def resolve_test_suite_flags(definition_config: Dict, suite_name: str, resources
                 json_name = json_file
             if json_name:
                 labels_json_path = os.path.join(resources_root, "json", json_name)
-    
+
     # Replace placeholders
     resolved_flags = []
     for flag in flags:
@@ -232,36 +232,36 @@ def resolve_test_suite_flags(definition_config: Dict, suite_name: str, resources
             resolved = resolved.replace("${LABELS_JSON_PATH}", labels_json_path)
         resolved = resolved.replace("${RESOURCES_ROOT}", resources_root)
         resolved_flags.append(resolved)
-    
+
     return resolved_flags
 
 
 def get_test_suites_for_mode(definition_config: Dict, app_name: str, test_suite_mode: str) -> List[str]:
     """Get test suites for an app based on test_suite_mode.
-    
+
     Args:
         definition_config: Test definition configuration
         app_name: Application name
         test_suite_mode: Test suite mode (None, default, extra, all)
-    
+
     Returns:
         List of test suite names (empty list if None)
     """
     if test_suite_mode == "None" or test_suite_mode is None:
         return []
-    
+
     if app_name not in definition_config.get("apps", {}):
         return []
-    
+
     app_config = definition_config["apps"][app_name]
     suites = []
-    
+
     if test_suite_mode in ["default", "all"]:
         suites.extend(app_config.get("default_test_suites", []))
-    
+
     if test_suite_mode in ["extra", "all"]:
         suites.extend(app_config.get("extra_test_suites", []))
-    
+
     return suites
 
 
@@ -274,7 +274,7 @@ def generate_test_cases(
     test_run_combination: Optional[str] = None,
 ) -> List[Dict]:
     """Generate test cases based on configuration.
-    
+
     Args:
         control_config: Test control configuration
         definition_config: Test definition configuration
@@ -282,24 +282,24 @@ def generate_test_cases(
         detected_hailo_arch: Detected Hailo architecture
         host_arch: Host architecture
         test_run_combination: Optional test run combination name
-    
+
     Returns:
         List of test case dictionaries
     """
     test_cases = []
-    
+
     # Get control parameters
     control_params = control_config.get("control_parameters", {})
     default_run_time = control_params.get("default_run_time", 24)
     term_timeout = control_params.get("term_timeout", 10)
-    
+
     # Get enabled run methods
     run_methods_config = control_config.get("run_methods", {})
     enabled_run_methods = [
         name for name, config in run_methods_config.items()
         if config.get("enabled", False)
     ]
-    
+
     # Determine which apps and modes to test
     # First check test_combinations in control_config
     test_combinations = control_config.get("test_combinations", {})
@@ -307,7 +307,7 @@ def generate_test_cases(
         name for name, config in test_combinations.items()
         if config.get("enabled", False)
     ]
-    
+
     if enabled_combinations:
         # Use first enabled test combination
         combination_name = enabled_combinations[0]
@@ -316,7 +316,7 @@ def generate_test_cases(
         if combination_name not in combinations:
             logger.warning(f"Test run combination {combination_name} not found in definition config")
             return []
-        
+
         combo = combinations[combination_name]
         apps_to_test = combo.get("apps", [])
         test_suite_mode = combo.get("test_suite_mode", combo.get("mode", "default"))  # Support both old and new format
@@ -327,7 +327,7 @@ def generate_test_cases(
         if test_run_combination not in combinations:
             logger.warning(f"Test run combination {test_run_combination} not found")
             return []
-        
+
         combo = combinations[test_run_combination]
         apps_to_test = combo.get("apps", [])
         test_suite_mode = combo.get("test_suite_mode", combo.get("mode", "default"))  # Support both old and new format
@@ -346,13 +346,13 @@ def generate_test_cases(
         # Default: no apps to test
         logger.warning("No test combination enabled and custom_tests disabled. No tests will run.")
         apps_to_test = []
-    
+
     # Determine architectures to test - only run tests for detected/specified architecture
     architectures = []
     if detected_hailo_arch:
         # Only run tests for the detected architecture
         architectures = [detected_hailo_arch]
-        
+
         # Special case: if hailo8 is detected and h8l_on_h8 special test is enabled,
         # also allow hailo8l tests (hailo8l models can run on hailo8 hardware)
         special_tests = control_config.get("special_tests", {})
@@ -364,7 +364,7 @@ def generate_test_cases(
         # If no device detected, don't run architecture-specific tests
         logger.warning("No Hailo device detected - skipping architecture-specific tests")
         architectures = []
-    
+
     # Generate test cases
     if isinstance(apps_to_test, list) and len(apps_to_test) > 0 and isinstance(apps_to_test[0], tuple):
         # Use individual app configurations (from custom_tests)
@@ -388,7 +388,7 @@ def generate_test_cases(
                 app_name, test_suite_mode, model_selection, architectures, enabled_run_methods,
                 default_run_time, term_timeout, host_arch
             )
-    
+
     logger.info(f"Generated {len(test_cases)} test cases")
     return test_cases
 
@@ -408,7 +408,7 @@ def generate_cases_for_app(
     host_arch: str,
 ):
     """Generate test cases for a specific app.
-    
+
     Args:
         test_cases: List to append test cases to
         control_config: Test control configuration
@@ -426,33 +426,37 @@ def generate_cases_for_app(
     if app_name not in definition_config.get("apps", {}):
         logger.warning(f"App {app_name} not found in definition config")
         return
-    
+
     app_def = definition_config["apps"][app_name]
-    
+
     # Get test suites for this test_suite_mode
     test_suites = get_test_suites_for_mode(definition_config, app_name, test_suite_mode)
-    
+
     # Filter out RPI camera tests if host is not rpi
     rpi_suites = ["basic_input_rpi", "input_rpi_with_hef", "input_rpi_with_labels"]
     if host_arch != "rpi":
         test_suites = [ts for ts in test_suites if ts not in rpi_suites]
-    
+
     for architecture in architectures:
         # Get models for this app and architecture based on model_selection
         models = get_models_for_app_and_arch(resources_config, app_name, architecture, model_selection)
         if not models:
             logger.info(f"No models for {app_name} on {architecture} with model_selection {model_selection}")
             continue
-                
+
         for model in models:
             for run_method in run_methods:
                 for test_suite in test_suites:
+                    # Constraint: gst-launch only runs on basic_input_video test suite
+                    if run_method == "gst-launch" and test_suite != "basic_input_video":
+                        continue
+
                     # Resolve test suite flags
                     flags = resolve_test_suite_flags(
                         definition_config, test_suite, resources_config,
                         app_name, architecture, model
                     )
-                    
+
                     test_cases.append({
                         "app": app_name,
                         "app_config": app_def,
@@ -481,7 +485,7 @@ def get_log_file_path_new(
     log_config = control_config.get("logging", {})
     subdirs = log_config.get("subdirs", {})
     per_app = subdirs.get("per_app", {})
-    
+
     # Get app-specific log directory
     if app_name in per_app:
         app_log_dirs = per_app[app_name]
@@ -490,10 +494,10 @@ def get_log_file_path_new(
         log_dir = app_log_dirs.get(log_mode, app_log_dirs.get("default", "./logs"))
     else:
         log_dir = log_config.get("base_dir", "./logs")
-    
+
     # Ensure directory exists
     os.makedirs(log_dir, exist_ok=True)
-    
+
     # Build filename
     parts = [app_name]
     if architecture:
@@ -506,7 +510,7 @@ def get_log_file_path_new(
         # Remove common prefixes for cleaner filenames
         suite_name = test_suite.replace("basic_", "").replace("input_", "").replace("pipeline_", "").replace("with_", "").replace("face_", "").replace("tiling_", "").replace("clip_", "").replace("multisource_", "")
         parts.append(suite_name)
-    
+
     filename = "_".join(parts) + ".log"
     return os.path.join(log_dir, filename)
 
@@ -545,12 +549,12 @@ def test_pipeline(test_case: Dict):
     term_timeout = test_case["term_timeout"]
     test_suite_mode = test_case.get("test_suite_mode", "default")
     model_selection = test_case.get("model_selection", "default")
-    
+
     # Get test function
     test_func = get_pipeline_test_function(app_name)
     if not test_func:
         pytest.skip(f"No test function for app: {app_name}")
-    
+
     # Build pipeline config for compatibility with existing test functions
     pipeline_config = {
         "name": app_config.get("name", app_name),
@@ -558,7 +562,7 @@ def test_pipeline(test_case: Dict):
         "script": app_config.get("script", ""),
         "cli": app_config.get("cli", ""),
     }
-    
+
     # Create a compatible config structure
     compatible_config = {
         "pipelines": {
@@ -578,18 +582,18 @@ def test_pipeline(test_case: Dict):
         },
         "logging": _control_config.get("logging", {}),
     }
-    
+
     # Get log file path
     log_file = get_log_file_path_new(
         _control_config, app_name, test_suite_mode, architecture, model, run_method, test_suite
     )
-    
+
     # Run test using existing framework
     stdout, stderr, success = run_pipeline_test(
         pipeline_config, model, architecture, run_method, flags, log_file,
         run_time=run_time, term_timeout=term_timeout
     )
-    
+
     # Assert success
     assert success, (
         f"App {app_name} with model {model} on {architecture} "
@@ -607,6 +611,6 @@ if __name__ == "__main__":
     logger.info(f"Hailo architecture: {_hailo_arch or 'None'}")
     logger.info(f"Total test cases: {len(_test_cases)}")
     logger.info("=" * 80)
-    
+
     pytest.main(["-v", __file__])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from hailo_apps.python.core.common.test_utils import (
     run_pipeline_cli_with_args,
     run_pipeline_module_with_args,
     run_pipeline_pythonpath_with_args,
+    run_pipeline_gst_launch_with_args,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,23 +26,24 @@ RUN_METHOD_FUNCTIONS = {
     "module": run_pipeline_module_with_args,
     "pythonpath": run_pipeline_pythonpath_with_args,
     "cli": run_pipeline_cli_with_args,
+    "gst-launch": run_pipeline_gst_launch_with_args,
 }
 
 
 def build_hef_path(model: str, architecture: str, resources_root: Optional[str] = None) -> str:
     """Build full path to HEF file.
-    
+
     Args:
         model: Model name (without .hef extension)
         architecture: Architecture (hailo8, hailo8l, hailo10h)
         resources_root: Resources root path (defaults to RESOURCES_ROOT_PATH_DEFAULT)
-    
+
     Returns:
         Full path to HEF file
     """
     if resources_root is None:
         resources_root = RESOURCES_ROOT_PATH_DEFAULT
-    
+
     hef_file = f"{model}.hef"
     return os.path.join(resources_root, "models", architecture, hef_file)
 
@@ -55,7 +57,7 @@ def build_test_args(
     extra_args: Optional[List[str]] = None,
 ) -> List[str]:
     """Build command-line arguments for a test.
-    
+
     Args:
         config: Full test configuration
         pipeline_config: Pipeline-specific configuration
@@ -63,21 +65,21 @@ def build_test_args(
         architecture: Architecture name
         test_suite: Test suite name (default: "default")
         extra_args: Additional arguments to append
-    
+
     Returns:
         List of command-line arguments
     """
     args = []
-    
+
     # Add HEF path
     hef_path = build_hef_path(model, architecture)
     args.extend(["--hef-path", hef_path])
-    
+
     # Add test suite arguments
     test_suites = config.get("test_suites", {})
     suite_config = test_suites.get(test_suite, {})
     suite_args = suite_config.get("args", [])
-    
+
     # Replace placeholders in suite args
     resources_root = config.get("resources", {}).get("root_path", RESOURCES_ROOT_PATH_DEFAULT)
     suite_args = [
@@ -85,13 +87,13 @@ def build_test_args(
         .replace("${RESOURCES_ROOT}", resources_root)
         for arg in suite_args
     ]
-    
+
     args.extend(suite_args)
-    
+
     # Add extra arguments if provided
     if extra_args:
         args.extend(extra_args)
-    
+
     return args
 
 
@@ -106,7 +108,7 @@ def run_pipeline_test(
     term_timeout: Optional[int] = None,
 ) -> Tuple[bytes, bytes, bool]:
     """Run a pipeline test and return results.
-    
+
     Args:
         pipeline_config: Pipeline configuration
         model: Model name
@@ -116,7 +118,7 @@ def run_pipeline_test(
         log_file: Path to log file
         run_time: Optional run time override
         term_timeout: Optional termination timeout override
-    
+
     Returns:
         Tuple of (stdout, stderr, success)
     """
@@ -124,50 +126,52 @@ def run_pipeline_test(
     if not run_func:
         logger.error(f"Unknown run method: {run_method}")
         return b"", b"Unknown run method".encode(), False
-    
+
     try:
         kwargs = {}
         if run_time is not None:
             kwargs["run_time"] = run_time
         if term_timeout is not None:
             kwargs["term_timeout"] = term_timeout
-        
+
         if run_method == "module":
             stdout, stderr = run_func(pipeline_config["module"], args, log_file, **kwargs)
         elif run_method == "pythonpath":
             stdout, stderr = run_func(pipeline_config["script"], args, log_file, **kwargs)
         elif run_method == "cli":
             stdout, stderr = run_func(pipeline_config["cli"], args, log_file, **kwargs)
+        elif run_method == "gst-launch":
+            stdout, stderr = run_func(pipeline_config["script"], args, log_file, **kwargs)
         else:
             return b"", b"Invalid run method".encode(), False
-        
+
         # Check for errors
         err_str = stderr.decode().lower() if stderr else ""
         out_str = stdout.decode().lower() if stdout else ""
         combined_output = (err_str + " " + out_str).lower()
-        
+
         success = "error" not in err_str and "traceback" not in err_str
-        
+
         # Check for FPS output when --show-fps is enabled
         if "--show-fps" in args or "-f" in args:
             if "fps:" not in combined_output:
                 logger.warning(f"FPS flag enabled but FPS output not found in logs: {log_file}")
                 # Don't fail the test, just warn - FPS might not appear immediately
-        
+
         # Check for QOS messages (these are warnings that may appear during pipeline operation)
         # QOS messages are normal during pipeline rebuild/startup, so we just log if they appear
         if "qos" in combined_output or "qoS" in combined_output:
             logger.warning(f"QOS messages detected in output (this is normal during pipeline operation)")
-        
+
         # but the pipeline still runs normally. Both enabled and disabled states result
         # in successful pipeline execution, so we cannot distinguish them from output.
         if "--disable-callback" in args:
             logger.debug("Testing with callback disabled - Python callback will not be invoked")
         else:
             logger.debug("Testing with callback enabled - Python callback will be invoked per frame")
-        
+
         return stdout, stderr, success
-        
+
     except Exception as e:
         logger.error(f"Exception running pipeline test: {e}")
         return b"", str(e).encode(), False
@@ -183,7 +187,7 @@ def get_log_file_path(
     test_suite: Optional[str] = None,
 ) -> str:
     """Get log file path for a test.
-    
+
     Args:
         config: Test configuration
         test_type: Type of test (e.g., "pipeline", "h8l_on_h8", "human_verification")
@@ -192,23 +196,23 @@ def get_log_file_path(
         model: Optional model name
         run_method: Optional run method name
         test_suite: Optional test suite name
-    
+
     Returns:
         Full path to log file
     """
     log_config = config.get("logging", {})
     base_dir = log_config.get("base_dir", "logs")
     subdirs = log_config.get("subdirectories", {})
-    
+
     # Get appropriate subdirectory
     if test_type in subdirs:
         log_dir = subdirs[test_type]
     else:
         log_dir = base_dir
-    
+
     # Ensure directory exists
     os.makedirs(log_dir, exist_ok=True)
-    
+
     # Build filename
     parts = [pipeline_name]
     if architecture:
@@ -219,28 +223,28 @@ def get_log_file_path(
         parts.append(run_method)
     if test_suite and test_suite != "default":
         parts.append(test_suite)
-    
+
     filename = "_".join(parts) + ".log"
     return os.path.join(log_dir, filename)
 
 
 def validate_test_config(config: Dict) -> Tuple[bool, List[str]]:
     """Validate test configuration.
-    
+
     Args:
         config: Test configuration dictionary
-    
+
     Returns:
         Tuple of (is_valid, list_of_errors)
     """
     errors = []
-    
+
     # Check required sections
     required_sections = ["execution", "logging", "pipelines", "run_methods"]
     for section in required_sections:
         if section not in config:
             errors.append(f"Missing required section: {section}")
-    
+
     # Check execution settings
     if "execution" in config:
         exec_config = config["execution"]
@@ -248,7 +252,7 @@ def validate_test_config(config: Dict) -> Tuple[bool, List[str]]:
             errors.append("Missing execution.default_run_time")
         if "term_timeout" not in exec_config:
             errors.append("Missing execution.term_timeout")
-    
+
     # Check pipelines
     if "pipelines" in config:
         for pipeline_name, pipeline_config in config["pipelines"].items():
@@ -256,7 +260,7 @@ def validate_test_config(config: Dict) -> Tuple[bool, List[str]]:
             for key in required_keys:
                 if key not in pipeline_config:
                     errors.append(f"Pipeline {pipeline_name} missing required key: {key}")
-    
+
     # Check run methods
     if "run_methods" in config:
         for rm in config["run_methods"]:
@@ -264,16 +268,16 @@ def validate_test_config(config: Dict) -> Tuple[bool, List[str]]:
                 errors.append("Run method missing 'name' field")
             if rm["name"] not in RUN_METHOD_FUNCTIONS:
                 errors.append(f"Unknown run method: {rm['name']}")
-    
+
     return len(errors) == 0, errors
 
 
 def get_enabled_pipelines(config: Dict) -> Dict[str, Dict]:
     """Get all enabled pipelines from configuration.
-    
+
     Args:
         config: Test configuration
-    
+
     Returns:
         Dictionary of enabled pipeline configurations
     """
@@ -287,10 +291,10 @@ def get_enabled_pipelines(config: Dict) -> Dict[str, Dict]:
 
 def get_enabled_run_methods(config: Dict) -> List[str]:
     """Get all enabled run methods from configuration.
-    
+
     Args:
         config: Test configuration
-    
+
     Returns:
         List of enabled run method names
     """
@@ -304,53 +308,52 @@ def get_enabled_run_methods(config: Dict) -> List[str]:
 
 def get_models_for_architecture(pipeline_config: Dict, architecture: str) -> List[str]:
     """Get models for a specific architecture from pipeline configuration.
-    
+
     Models can be specified in two ways:
     1. "default" key - models available for all architectures
     2. Architecture-specific key (e.g., "hailo8", "hailo8l", "hailo10h") - models specific to that architecture
-    
+
     The function combines default models with architecture-specific models.
-    
+
     Args:
         pipeline_config: Pipeline configuration
         architecture: Architecture name
-    
+
     Returns:
         List of model names for the architecture (default + architecture-specific)
     """
     models_config = pipeline_config.get("models", {})
     models = []
-    
+
     # Add default models (available for all architectures)
     if "default" in models_config:
         models.extend(models_config["default"])
-    
+
     # Add architecture-specific models
     if architecture in models_config:
         models.extend(models_config[architecture])
-    
+
     return models
 
 
 def expand_test_suite_args(config: Dict, suite_name: str, **replacements) -> List[str]:
     """Expand test suite arguments with replacements.
-    
+
     Args:
         config: Test configuration
         suite_name: Test suite name
         **replacements: Key-value pairs for placeholder replacement
-    
+
     Returns:
         List of expanded arguments
     """
     test_suites = config.get("test_suites", {})
     suite_config = test_suites.get(suite_name, {})
     args = suite_config.get("args", [])
-    
+
     # Apply replacements
     for key, value in replacements.items():
         placeholder = f"${{{key}}}"
         args = [arg.replace(placeholder, str(value)) for arg in args]
-    
-    return args
 
+    return args


### PR DESCRIPTION
This commit implements the --get-gst-launch flag that allows pipeline applications to output a ready-to-use gst-launch-1.0 command string.

Core Changes:
- Add --get-gst-launch argument to pipeline parser (core.py)
- Implement flag check in create_pipeline() to print pipeline and exit (gstreamer_app.py)
- Output format: 'gst-launch-1.0 <pipeline_string>'

Test Infrastructure:
- Add run_pipeline_gst_launch_with_args() function (test_utils.py)
- Register 'gst-launch' run method in test framework (test_utils.py)
- Add constraint: gst-launch only runs on basic_input_video suite (test_runner.py)

Cleanup:
- Remove excessive pipeline string logging (changed info -> debug)
- Conditionally suppress configuration printout when using --get-gst-launch

Documentation:
- Add notes to unsupported apps (face_recognition, clip, reid_multisource)
- Explain why they require Python logic and cannot run CLI-only

Supported Apps: detection, detection_simple, pose_estimation, instance_segmentation, depth, tiling, paddle_ocr, multisource

Unsupported Apps: face_recognition (requires DB operations), clip (requires text matching & GUI), reid_multisource (requires cross-camera tracking DB)