### PR TITLE
Fix signal.signal() thread safety in shutdown()

### DIFF
--- a/hailo_apps/python/core/gstreamer/gstreamer_app.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_app.py
@@ -619,7 +619,9 @@ class GStreamerApp:
             self.watchdog_thread = None
 
         print("Shutting down... Hit Ctrl-C again to force quit.")
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        # signal.signal() may only be called from the main thread (e.g. EOS/shutdown from pipeline thread)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
         self.pipeline.set_state(Gst.State.PAUSED)
         GLib.usleep(100000)
 


### PR DESCRIPTION
signal.signal() may only be called from the main thread. Guard the call so it is skipped when shutdown is triggered from a GStreamer pipeline thread.