### PR TITLE
Add UDP source type for H264 RTP streams

### DIFF
--- a/hailo_apps/python/core/gstreamer/gstreamer_helper_pipelines.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_helper_pipelines.py
@@ -51,6 +51,8 @@ def get_source_type(input_source):
         return "ximage"
     elif input_source.startswith('rtsp://'):
         return 'rtsp'
+    elif input_source.startswith('udp://'):
+        return 'udp'
     else:
         return "file"
 
@@ -155,6 +157,17 @@ def SOURCE_PIPELINE(
             f'rtspsrc location="{video_source}" name={name} ! '
             f'{QUEUE(name=f"{name}_queue_decode")} ! '
             f'decodebin name={name}_decodebin ! '
+        )
+    elif source_type == 'udp':  # UDP stream handling (e.g., Gazebo camera)
+        # Extract port from udp://host:port or udp://:port
+        port = video_source.split(':')[-1]
+        source_element = (
+            f'udpsrc port={port} name={name} ! '
+            f'application/x-rtp, encoding-name=H264, payload=96 ! '
+            f'{QUEUE(name=f"{name}_queue_decode")} ! '
+            f'rtph264depay ! '
+            f'h264parse ! '
+            f'avdec_h264 name={name}_decodebin ! '
         )
     else:
         source_element = (


### PR DESCRIPTION
Support udp:// input sources (e.g., Gazebo camera) by extracting the port and building a udpsrc ! rtph264depay ! h264parse ! avdec_h264 pipeline.