### PR TITLE
Fix Picamera2 resolution: use max resolution for main stream

### DIFF
--- a/hailo_apps/python/core/gstreamer/gstreamer_app.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_app.py
@@ -737,31 +737,21 @@ def picamera_thread(pipeline, video_width, video_height, video_format, picamera_
 
     with Picamera2() as picam2:
         if picamera_config is None:
-            # Determine main stream size: must be >= lores for Picamera2.
-            # get_camera_resolution returns the nearest standard resolution >= requested.
-            main_width, main_height = get_camera_resolution(video_width, video_height)
+            # Ensure main >= lores (Picamera2 requirement)
+            # Use camera's max resolution for main to support any lores size
+            main_width = max(2592, video_width)
+            main_height = max(1944, video_height)
             main = {"size": (main_width, main_height), "format": "RGB888"}
+            lores = {"size": (video_width, video_height), "format": "RGB888"}
             controls = {"FrameRate": 30}
-
-            # If the main and requested sizes match, Picamera2 requires lores < main,
-            # so we skip lores and capture directly from the main stream.
-            if main_width == video_width and main_height == video_height:
-                config = picam2.create_preview_configuration(main=main, controls=controls)
-                capture_stream = "main"
-            else:
-                lores = {"size": (video_width, video_height), "format": "RGB888"}
-                config = picam2.create_preview_configuration(
-                    main=main, lores=lores, controls=controls
-                )
-                capture_stream = "lores"
+            config = picam2.create_preview_configuration(main=main, lores=lores, controls=controls)
         else:
             config = picamera_config
-            capture_stream = "lores" if "lores" in config else "main"
 
         picam2.configure(config)
-        stream_config = config.get(capture_stream, config["main"])
-        format_str = "RGB" if stream_config["format"] == "RGB888" else video_format
-        width, height = stream_config["size"]
+        lores_stream = config["lores"]
+        format_str = "RGB" if lores_stream["format"] == "RGB888" else video_format
+        width, height = lores_stream["size"]
         hailo_logger.debug(f"Picamera2 config: width={width}, height={height}, format={format_str}")
 
         appsrc.set_property(
@@ -775,7 +765,7 @@ def picamera_thread(pipeline, video_width, video_height, video_format, picamera_
         hailo_logger.info("picamera_process started")
 
         while True:
-            frame_data = picam2.capture_array(capture_stream)
+            frame_data = picam2.capture_array("lores")
             if frame_data is None:
                 hailo_logger.error("Failed to capture frame")
                 break


### PR DESCRIPTION
Always set main stream to camera max resolution (2592x1944) and always capture from lores stream. Eliminates edge case where main==lores size caused Picamera2 to fail.