### PR TITLE
fix: guard framerate caps on frame_rate being not None

### DIFF
--- a/hailo_apps/python/core/gstreamer/gstreamer_helper_pipelines.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_helper_pipelines.py
@@ -191,9 +191,9 @@ def SOURCE_PIPELINE(
         )
 
     # Set up the fps caps.
-    # If sync is True, constrain the rate with the given frame_rate.
+    # If sync is True and frame_rate is specified, constrain the rate.
     # Otherwise, pass through (no framerate limitation).
-    if sync:
+    if sync and frame_rate is not None:
         fps_caps = f"video/x-raw, framerate={frame_rate}/1"
     else:
         fps_caps = "video/x-raw"


### PR DESCRIPTION
When sync=True but frame_rate is None (e.g. decodebin from file), SOURCE_PIPELINE would produce 'framerate=None/1' which GStreamer rejects. Now only constrains framerate when both sync=True AND frame_rate is explicitly provided.