### PR TITLE
fix: rename lane_detection/super_resolution to _standalone in test co…

### DIFF
--- a/hailo_apps/config/test_definition_config.yaml
+++ b/hailo_apps/config/test_definition_config.yaml
@@ -654,8 +654,8 @@ test_run_combinations:
       - paddle_ocr
       - clip
       - retrain
-      - lane_detection
-      - super_resolution
+      - lane_detection_standalone
+      - super_resolution_standalone
       - reid_multisource
     test_suite_mode: "all"  # None | default | extra | all
     model_selection: "all"  # default | extra | all
@@ -674,8 +674,8 @@ test_run_combinations:
       - paddle_ocr
       - clip
       - retrain
-      - lane_detection
-      - super_resolution
+      - lane_detection_standalone
+      - super_resolution_standalone
       - reid_multisource
     test_suite_mode: "default"  # None | default | extra | all
     model_selection: "default"  # default | extra | all
@@ -694,8 +694,8 @@ test_run_combinations:
       - paddle_ocr
       - clip
       - retrain
-      - lane_detection
-      - super_resolution
+      - lane_detection_standalone
+      - super_resolution_standalone
       - reid_multisource
     test_suite_mode: "extra"  # None | default | extra | all
     model_selection: "extra"  # default | extra | all

--- a/tests/test_control.yaml
+++ b/tests/test_control.yaml
@@ -161,15 +161,15 @@ custom_tests:
       model_selection: "default"  # default | extra | all
       description: "CLIP Pipeline"
 
-    lane_detection:
+    lane_detection_standalone:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
-      description: "Lane Detection Pipeline"
+      description: "Lane Detection Standalone"
 
-    super_resolution:
+    super_resolution_standalone:
       test_suite_mode: "default"  # None | default | extra | all
       model_selection: "default"  # default | extra | all
-      description: "Super Resolution Pipeline"
+      description: "Super Resolution Standalone"
 
 # Per-app run-time overrides (seconds)
 # Use this to give slow-starting apps extra time beyond the default_run_time.


### PR DESCRIPTION
…nfigs

These apps only exist as standalone apps, not pipeline apps. The custom_tests in test_control.yaml and test_run_combinations in test_definition_config.yaml referenced non-existent app definitions.