### PR TITLE
fix: skip CLI tests for apps without CLI entry point

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -386,6 +386,9 @@ def _generate_cases_for_app(
 
         for model in model_list:
             for run_method in run_methods:
+                # Skip CLI tests for apps without a CLI entry point
+                if run_method == "cli" and not app_def.cli:
+                    continue
                 for test_suite in test_suites:
                     flags = resolve_test_suite_flags(
                         test_suite, app_name, architecture, model

--- a/tests/test_standalone_runner.py
+++ b/tests/test_standalone_runner.py
@@ -333,6 +333,9 @@ def generate_test_cases(
 
             for model in model_list:
                 for run_method in run_methods:
+                    # Skip CLI tests for apps without a CLI entry point
+                    if run_method == "cli" and not app_def.cli:
+                        continue
                     for suite in suites:
                         test_cases.append(
                             {


### PR DESCRIPTION
When an app definition has cli: '' (empty), the test runners would try to execute an empty string as a command, causing Permission denied errors. Now both test_runner.py and test_standalone_runner.py skip CLI test case generation when the app has no CLI entry point registered.