### PR TITLE
fix: update cleanup_installation.sh for upgrade-in-place

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ cd hailo-apps
 sudo ./install.sh
 ```
 
+### Upgrading
+
+When upgrading to a new version, use `--force-cleanup` to remove stale build artifacts before reinstalling:
+
+```bash
+git pull
+sudo ./install.sh --force-cleanup
+```
+
 ### Quick Examples
 
 ```bash

--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -13,6 +13,7 @@ This guide provides instructions for installing the Hailo Application Infrastruc
 - [Manual Installation (Advanced)](#manual-installation-advanced)
 - [Hailo Suite Docker Installation](#hailo-suite-docker-installation)
 - [Post-Installation Verification](#post-installation-verification)
+- [Upgrading / Reinstalling](#upgrading--reinstalling)
 - [Uninstallation](#uninstallation)
 
 **Installing Hailo Packages (Prerequisites)**
@@ -407,6 +408,7 @@ After running any of the installation methods, you can verify that everything is
 *   **Driver Issues (RPi)**: If you see driver errors, ensure your kernel is up to date (`sudo apt update && sudo apt full-upgrade`).
 *   **`DEVICE_IN_USE()` Error**: This means the Hailo device is being used by another process. Run the cleanup script: `./scripts/kill_first_hailo.sh`.
 *   **GStreamer `cannot allocate memory in static TLS block` (RPi)**: This is a known issue. Add `export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1` to your `~/.bashrc` file and reboot.
+*   **Build Errors After Upgrade**: If you see ninja/meson errors or missing `.so` references after pulling a new version, run `sudo ./scripts/cleanup_installation.sh` followed by `sudo ./install.sh` to clear stale build caches.
 *   **Emoji Display Issues (RPi)**: If emoji icons (❌, ✅, etc.) are not displaying correctly in terminal output, install the Noto Color Emoji font:
     ```bash
     sudo apt-get update
@@ -420,6 +422,20 @@ After running any of the installation methods, you can verify that everything is
     ```
 
 </details>
+
+---
+
+## Upgrading / Reinstalling
+
+When upgrading to a new version of hailo-apps, run the cleanup script first to remove stale build artifacts (e.g., old C++ postprocess caches) that can break recompilation:
+
+```bash
+git pull
+sudo ./scripts/cleanup_installation.sh
+sudo ./install.sh
+```
+
+> **Note:** The cleanup script removes the virtual environment, build caches, and downloaded resources. A fresh `install.sh` will recreate everything.
 
 ---
 

--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -408,7 +408,7 @@ After running any of the installation methods, you can verify that everything is
 *   **Driver Issues (RPi)**: If you see driver errors, ensure your kernel is up to date (`sudo apt update && sudo apt full-upgrade`).
 *   **`DEVICE_IN_USE()` Error**: This means the Hailo device is being used by another process. Run the cleanup script: `./scripts/kill_first_hailo.sh`.
 *   **GStreamer `cannot allocate memory in static TLS block` (RPi)**: This is a known issue. Add `export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1` to your `~/.bashrc` file and reboot.
-*   **Build Errors After Upgrade**: If you see ninja/meson errors or missing `.so` references after pulling a new version, run `sudo ./scripts/cleanup_installation.sh` followed by `sudo ./install.sh` to clear stale build caches.
+*   **Build Errors After Upgrade**: If you see ninja/meson errors or missing `.so` references after pulling a new version, run `sudo ./install.sh --force-cleanup` to clear stale build caches and reinstall cleanly.
 *   **Emoji Display Issues (RPi)**: If emoji icons (❌, ✅, etc.) are not displaying correctly in terminal output, install the Noto Color Emoji font:
     ```bash
     sudo apt-get update
@@ -427,15 +427,22 @@ After running any of the installation methods, you can verify that everything is
 
 ## Upgrading / Reinstalling
 
-When upgrading to a new version of hailo-apps, run the cleanup script first to remove stale build artifacts (e.g., old C++ postprocess caches) that can break recompilation:
+When upgrading to a new version of hailo-apps, use the `--force-cleanup` flag to remove stale build artifacts (e.g., old C++ postprocess caches) before reinstalling:
+
+```bash
+git pull
+sudo ./install.sh --force-cleanup
+```
+
+> **Note:** `--force-cleanup` removes the virtual environment, build caches, and downloaded resources before installation begins. Everything is recreated by `install.sh`.
+
+Alternatively, you can run the cleanup script manually before installing:
 
 ```bash
 git pull
 sudo ./scripts/cleanup_installation.sh
 sudo ./install.sh
 ```
-
-> **Note:** The cleanup script removes the virtual environment, build caches, and downloaded resources. A fresh `install.sh` will recreate everything.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,7 @@ fi
 #===============================================================================
 
 DRY_RUN=false
+FORCE_CLEANUP=false
 NO_INSTALL=false
 NO_SYSTEM_PYTHON=false
 NO_TAPPAS_REQUIRED=false
@@ -614,6 +615,8 @@ ${BOLD}OPTIONS:${NC}
     --no-tappas-required        Skip TAPPAS checks, Python TAPPAS install, compile, and post_install
                                 (downloads resources directly, no C++ compilation)
     --dry-run                   Show what would be done without executing
+    --force-cleanup             Run cleanup script before installation (removes venv,
+                                build caches, and resources — useful for upgrades)
     -h, --help                  Show this help message
 
 ${BOLD}CONFIGURATION:${NC}
@@ -621,11 +624,12 @@ ${BOLD}CONFIGURATION:${NC}
     CLI arguments override config file values.
 
 ${BOLD}EXAMPLES:${NC}
-    sudo $SCRIPT_NAME                     # Standard installation
-    sudo $SCRIPT_NAME --dry-run           # Preview what would be done
-    sudo $SCRIPT_NAME --all               # Install with all models
-    sudo $SCRIPT_NAME -x                  # Skip Python package installation
-    sudo $SCRIPT_NAME -n my_venv --all    # Custom venv name + all models
+    sudo $SCRIPT_NAME                          # Standard installation
+    sudo $SCRIPT_NAME --dry-run                # Preview what would be done
+    sudo $SCRIPT_NAME --all                    # Install with all models
+    sudo $SCRIPT_NAME -x                       # Skip Python package installation
+    sudo $SCRIPT_NAME -n my_venv --all         # Custom venv name + all models
+    sudo $SCRIPT_NAME --force-cleanup          # Clean stale artifacts then install
 
 ${BOLD}LOG FILES:${NC}
     Installation logs: ${LOG_DIR}/
@@ -679,6 +683,10 @@ parse_arguments() {
                 ;;
             --no-tappas-required)
                 NO_TAPPAS_REQUIRED=true
+                shift
+                ;;
+            --force-cleanup)
+                FORCE_CLEANUP=true
                 shift
                 ;;
             --dry-run)
@@ -1293,6 +1301,7 @@ run_post_install() {
         log_error "Post-installation failed (exit code: ${post_install_exit})"
         echo ""
         log_info "Common causes and solutions:"
+        log_info "  • Stale build cache (upgrade/downgrade): Re-run with: sudo $SCRIPT_NAME --force-cleanup"
         log_info "  • Network issues: Check internet connection for resource downloads"
         log_info "  • Permission issues: Try running: sudo chown -R ${ORIGINAL_USER}:${ORIGINAL_GROUP} ${SCRIPT_DIR}"
         log_info "  • C++ compilation: Ensure meson and ninja-build are installed"
@@ -1535,6 +1544,26 @@ main() {
     fi
     if [[ -n "${MODEL_ZOO_MAPPING:-}" ]]; then
         log_debug "Model Zoo mapping: ${MODEL_ZOO_MAPPING}"
+    fi
+
+    # Force cleanup before installation if requested
+    if [[ "${FORCE_CLEANUP}" == true ]]; then
+        local cleanup_script="${SCRIPT_DIR}/scripts/cleanup_installation.sh"
+        log_info "Running cleanup before installation (--force-cleanup)..."
+        if [[ ! -x "${cleanup_script}" ]]; then
+            log_error "Cleanup script not found or not executable: ${cleanup_script}"
+            exit 1
+        fi
+        if [[ "${DRY_RUN}" == true ]]; then
+            log_dry_run "sudo ${cleanup_script}"
+        else
+            if ! bash "${cleanup_script}" > /dev/null; then
+                log_error "Cleanup script failed. Aborting installation."
+                exit 1
+            fi
+            log_success "Cleanup completed"
+        fi
+        echo ""
     fi
 
     # Run installation steps

--- a/scripts/cleanup_installation.sh
+++ b/scripts/cleanup_installation.sh
@@ -1,7 +1,44 @@
 #!/bin/bash
-# Cleanup installation artifacts from hailo-apps
+# Cleanup all installation artifacts from hailo-apps.
+# Run this BEFORE re-running ./install.sh when upgrading in-place.
+# This ensures stale build artifacts (e.g. old TAPPAS .so references in
+# the Meson/Ninja build cache) don't break recompilation.
+#
+# Usage:
+#   sudo ./scripts/cleanup_installation.sh
+#   sudo ./install.sh
 
 set -euo pipefail
 
-sudo rm -rf resources hailo_apps.egg-info/ venv_hailo_apps/ hailort.log 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+echo "Cleaning hailo-apps installation artifacts..."
+
+# Python package build artifacts
+sudo rm -rf hailo_apps.egg-info/ build/ dist/
+
+# Virtual environment
+sudo rm -rf venv_hailo_apps/
+
+# Resources symlink and system resources
+sudo rm -rf resources
 sudo rm -rf /usr/local/hailo/resources/
+
+# C++ postprocess build artifacts (stale build.ninja causes ninja errors on upgrade)
+sudo rm -rf hailo_apps/postprocess/build.release/
+
+# HailoRT logs
+sudo rm -f hailort.log hailo_apps/postprocess/hailort.log
+
+# Installation session logs (preserve app/test log subdirs)
+sudo rm -f logs/install_*.log
+
+# Python bytecode caches
+find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+
+# Pytest cache
+sudo rm -rf .pytest_cache/
+
+echo "Cleanup complete. You can now run: sudo ./install.sh"


### PR DESCRIPTION
Add missing artifacts that cause stale build failures when upgrading hailo-apps in-place (without fresh clone):

- hailo_apps/postprocess/build.release/ (stale Meson/Ninja cache referencing old TAPPAS .so versions causes ninja errors)
- hailo_apps/postprocess/hailort.log
- build/, dist/ (Python build artifacts)
- __pycache__/ directories (stale bytecode)
- .pytest_cache/
- logs/install_*.log (accumulated session logs)

Also add REPO_ROOT-relative paths and usage instructions in header.