### PR TITLE
Feature/pipeline lifecycle and tests

### DIFF
--- a/hailo_apps/python/core/common/parser.py
+++ b/hailo_apps/python/core/common/parser.py
@@ -244,6 +244,17 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
         help="Enable vertical mirror (flip) of the video source. Useful when camera is mounted upside down.",
     )
 
+    parser.add_argument(
+        "--run-duration",
+        type=float,
+        default=None,
+        help=(
+            "Run the pipeline for the specified number of seconds, then shut down gracefully. "
+            "Useful for profiling, benchmarking, and automated testing. "
+            "The pipeline performs a clean shutdown (EOS) so that trace data is flushed."
+        ),
+    )
+
     return parser
 
 

--- a/hailo_apps/python/core/gstreamer/gstreamer_app.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_app.py
@@ -482,6 +482,11 @@ class GStreamerApp:
             self.on_eos()
         elif t == Gst.MessageType.ERROR:
             err, debug = message.parse_error()
+            # Ignore errors during pipeline rebuild — the rebuild retry loop
+            # handles failed attempts by tearing down and retrying.
+            if getattr(self, "watchdog_paused", False):
+                hailo_logger.debug(f"Ignoring error during rebuild: {err}")
+                return True
             hailo_logger.error(f"GStreamer Error: {err}, debug: {debug}")
             self.error_occurred = True
             self.shutdown()
@@ -500,7 +505,13 @@ class GStreamerApp:
         hailo_logger.debug("on_eos() called")
         if self.source_type == "file":
             hailo_logger.info("File source detected; rebuilding pipeline")
-            # Use GLib.idle_add to defer pipeline rebuild and avoid blocking
+            # Stop the old pipeline immediately to release the HailoRT device
+            # before scheduling the rebuild. Without this, elements in the old
+            # pipeline can error out (e.g., hailonet device conflicts) and
+            # trigger shutdown() via bus_call before the rebuild gets to run.
+            if self.pipeline:
+                self.pipeline.set_state(Gst.State.NULL)
+                self.pipeline.get_state(2 * Gst.SECOND)
             GLib.idle_add(self._rebuild_pipeline)
         else:
             hailo_logger.debug("Non-file source detected; shutting down")
@@ -557,6 +568,15 @@ class GStreamerApp:
         self.rebuild_count += 1
 
         try:
+            # Step 0: Terminate the display process if running — it holds
+            # inherited file descriptors (including /dev/hailo0) from fork(),
+            # which prevents the HailoRT device from being released.
+            if self.display_process is not None and self.display_process.is_alive():
+                hailo_logger.debug("Terminating display process for rebuild")
+                self.display_process.terminate()
+                self.display_process.join(timeout=3)
+                self.display_process = None
+
             # Step 1: Stop and destroy the old pipeline
             hailo_logger.debug("Stopping old pipeline")
             if self.pipeline:
@@ -571,32 +591,69 @@ class GStreamerApp:
 
             hailo_logger.debug("Old pipeline destroyed")
 
-            # Small delay to ensure all resources are released
-            time.sleep(0.2)
+            # Step 2: Wait for the HailoRT device to become available.
+            # Device release is asynchronous — after pipeline destruction,
+            # the driver may need time to free the physical device.
+            # We probe with VDevice() before rebuilding to avoid creating
+            # a broken pipeline (which can segfault during cleanup).
+            max_wait = 10  # seconds
+            poll_interval = 0.5
+            device_ready = False
+            try:
+                from hailo_platform import VDevice
+                elapsed = 0.0
+                while elapsed < max_wait:
+                    time.sleep(poll_interval)
+                    elapsed += poll_interval
+                    try:
+                        vd = VDevice()
+                        del vd
+                        device_ready = True
+                        hailo_logger.debug(
+                            "Hailo device available after %.1fs", elapsed,
+                        )
+                        break
+                    except Exception:
+                        hailo_logger.debug(
+                            "Hailo device not ready after %.1fs, retrying...",
+                            elapsed,
+                        )
+            except ImportError:
+                # hailo_platform not available — fall back to fixed delay
+                hailo_logger.debug("hailo_platform not available, using fixed delay")
+                time.sleep(2.0)
+                device_ready = True
 
-            # Step 2: Rebuild the pipeline from scratch
-            hailo_logger.debug("Creating new pipeline")
+            if not device_ready:
+                hailo_logger.error(
+                    "Hailo device not available after %.1fs — cannot rebuild pipeline",
+                    max_wait,
+                )
+                self.loop.quit()
+                return False
+
+            # Step 3: Build and start the new pipeline
             pipeline_string = self.get_pipeline_string()
             hailo_logger.debug(f"New pipeline string: {pipeline_string}")
 
             self.pipeline = Gst.parse_launch(pipeline_string)
 
-            # Step 3: Reattach bus callback
+            # Step 4: Reattach bus callback
             hailo_logger.debug("Reattaching bus callback")
             bus = self.pipeline.get_bus()
             bus.add_signal_watch()
             bus.connect("message", self.bus_call, self.loop)
 
-            # Step 4: Reattach callback
+            # Step 5: Reattach callback
             self._connect_callback()
 
-            # Step 4b: Call hook for subclass-specific reconnections
+            # Step 5b: Call hook for subclass-specific reconnections
             self._on_pipeline_rebuilt()
 
-            # Step 5: Disable QoS on all elements to prevent frame drops
+            # Step 6: Disable QoS on all elements to prevent frame drops
             disable_qos(self.pipeline)
 
-            # Step 6: Start the new pipeline
+            # Step 7: Start the new pipeline
             hailo_logger.debug("Starting new pipeline")
             ret = self.pipeline.set_state(Gst.State.PLAYING)
             if ret == Gst.StateChangeReturn.FAILURE:
@@ -605,6 +662,14 @@ class GStreamerApp:
                 return False
 
             hailo_logger.debug("Pipeline rebuilt and restarted successfully")
+
+            # Restart display process if use_frame is enabled
+            if self.options_menu.use_frame:
+                hailo_logger.debug("Restarting display process after rebuild")
+                self.display_process = multiprocessing.Process(
+                    target=display_user_data_frame, args=(self.user_data,)
+                )
+                self.display_process.start()
 
             # Resume watchdog monitoring
             self.watchdog_paused = False
@@ -717,12 +782,13 @@ class GStreamerApp:
 
         disable_qos(self.pipeline)
 
+        self.display_process = None
         if self.options_menu.use_frame:
             hailo_logger.debug("Starting display_user_data_frame process")
-            display_process = multiprocessing.Process(
+            self.display_process = multiprocessing.Process(
                 target=display_user_data_frame, args=(self.user_data,)
             )
-            display_process.start()
+            self.display_process.start()
 
         if self.source_type == RPI_NAME_I:
             hailo_logger.debug("Starting picamera_thread")
@@ -760,9 +826,9 @@ class GStreamerApp:
             if self.pipeline.get_state(0).state != Gst.State.NULL:
                 self.pipeline.set_state(Gst.State.NULL)
                 self.pipeline.get_state(5 * Gst.SECOND)
-            if self.options_menu.use_frame:
-                display_process.terminate()
-                display_process.join()
+            if self.display_process is not None:
+                self.display_process.terminate()
+                self.display_process.join()
             for t in self.threads:
                 t.join()
         except Exception as e:

--- a/hailo_apps/python/core/gstreamer/gstreamer_app.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_app.py
@@ -107,6 +107,7 @@ class app_callback_class:
     Attributes:
         frame_count (int): Current frame number (auto-incremented by framework)
         use_frame (bool): Whether to extract frame data in callback
+        window_title (str): Title for the OpenCV display window (default: "User Frame")
         frame_queue (Queue): Queue for passing frames to display thread
         running (bool): Flag to control thread lifecycle
         callback_times (list): Debug mode - stores callback execution times
@@ -116,6 +117,7 @@ class app_callback_class:
         hailo_logger.debug("Initializing app_callback_class")
         self.frame_count = 0
         self.use_frame = False
+        self.window_title = "User Frame"
         self.frame_queue = multiprocessing.Queue(maxsize=3)
         self.running = True
         # Debug mode timing statistics
@@ -629,13 +631,23 @@ class GStreamerApp:
         # signal.signal() may only be called from the main thread (e.g. EOS/shutdown from pipeline thread)
         if threading.current_thread() is threading.main_thread():
             signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+        # Remove bus signal watch before state transitions to prevent
+        # callbacks firing during teardown
+        bus = self.pipeline.get_bus()
+        bus.remove_signal_watch()
+
         self.pipeline.set_state(Gst.State.PAUSED)
-        GLib.usleep(100000)
+        self.pipeline.get_state(2 * Gst.SECOND)
 
         self.pipeline.set_state(Gst.State.READY)
-        GLib.usleep(100000)
+        self.pipeline.get_state(2 * Gst.SECOND)
 
         self.pipeline.set_state(Gst.State.NULL)
+        # Wait for NULL to complete so HailoRT device is fully released
+        # before the process exits — prevents the std::system_error race
+        self.pipeline.get_state(5 * Gst.SECOND)
+
         GLib.idle_add(self.loop.quit)
 
     def update_fps_caps(self, new_fps=30, source_name="source"):
@@ -733,13 +745,21 @@ class GStreamerApp:
         if self.options_menu.dump_dot:
             GLib.timeout_add_seconds(3, self.dump_dot_file)
 
+        run_duration = getattr(self.options_menu, "run_duration", None)
+        if run_duration is not None:
+            GLib.timeout_add(int(run_duration * 1000), self.shutdown)
+            hailo_logger.info(f"Pipeline will shut down after {run_duration}s")
+
         self.loop.run()
         # Gtk.main()
 
         try:
             hailo_logger.debug("Cleaning up after loop exit")
             self.user_data.running = False
-            self.pipeline.set_state(Gst.State.NULL)
+            # Pipeline is already NULL from shutdown() — only set if still active
+            if self.pipeline.get_state(0).state != Gst.State.NULL:
+                self.pipeline.set_state(Gst.State.NULL)
+                self.pipeline.get_state(5 * Gst.SECOND)
             if self.options_menu.use_frame:
                 display_process.terminate()
                 display_process.join()

--- a/hailo_apps/python/core/gstreamer/gstreamer_common.py
+++ b/hailo_apps/python/core/gstreamer/gstreamer_common.py
@@ -56,13 +56,17 @@ def disable_qos(pipeline):
 def display_user_data_frame(user_data):
     """
     Displays frames from user_data in a window.
+
+    The window title defaults to "User Frame" and can be customized per-app
+    by setting user_data.window_title before app.run().
     """
-    hailo_logger.debug("display_user_data_frame() started")
+    title = getattr(user_data, "window_title", "User Frame")
+    hailo_logger.debug("display_user_data_frame() started (title=%s)", title)
     while user_data.running:
         frame = user_data.get_frame()
         if frame is not None:
             hailo_logger.debug("Displaying user frame")
-            cv2.imshow("User Frame", frame)
+            cv2.imshow(title, frame)
         cv2.waitKey(1)
     hailo_logger.debug("display_user_data_frame() exiting")
     cv2.destroyAllWindows()

--- a/tests/test_face_recon.py
+++ b/tests/test_face_recon.py
@@ -2,21 +2,19 @@
 # Standard library imports
 import os
 import logging
+import re
 
 # Third-party imports
 import pytest
 
 # Local application-specific imports
-from hailo_apps.hailo_app_python.core.common.test_utils import (
-    run_pipeline_module_with_args, 
-    run_pipeline_pythonpath_with_args, 
-    run_pipeline_cli_with_args, 
-    get_pipeline_args,
-    check_hailo8l_on_hailo8_warning,
-    check_qos_performance_warning,
+from test_utils import (
+    run_pipeline_module_with_args,
+    run_pipeline_pythonpath_with_args,
+    run_pipeline_cli_with_args,
 )
-from hailo_apps.hailo_app_python.core.common.installation_utils import detect_hailo_arch
-from hailo_apps.hailo_app_python.core.common.defines import HAILO8_ARCH, HAILO8L_ARCH, RESOURCES_ROOT_PATH_DEFAULT
+from hailo_apps.python.core.common.installation_utils import detect_hailo_arch
+from hailo_apps.python.core.common.defines import HAILO8_ARCH, HAILO8L_ARCH, RESOURCES_ROOT_PATH_DEFAULT
 # endregion imports
 
 # Configure logging as needed.
@@ -25,12 +23,55 @@ logger = logging.getLogger('test_run_everything')
 log_dir = "logs"
 os.makedirs(log_dir, exist_ok=True)
 
-# Define pipeline configurations.
+
+# ============================================================================
+# Helper functions (previously in old test_utils module)
+# ============================================================================
+
+def get_pipeline_args(suite='default'):
+    """Build pipeline args for a given test suite."""
+    args = []
+    if suite == 'mode-train':
+        args.extend(["--mode", "train"])
+    elif suite == 'mode-delete':
+        args.extend(["--mode", "delete"])
+    elif suite == 'usb_camera':
+        args.extend(["--input", "usb"])
+    # default suite has no extra args
+    return args
+
+
+def check_qos_performance_warning(stdout, stderr):
+    """Check for QoS performance warnings in output."""
+    combined = ""
+    if stdout:
+        combined += stdout.decode(errors='replace').lower()
+    if stderr:
+        combined += stderr.decode(errors='replace').lower()
+    qos_matches = re.findall(r'qos', combined)
+    count = len(qos_matches)
+    return (count >= 100, count)
+
+
+def check_hailo8l_on_hailo8_warning(stdout, stderr):
+    """Check for HailoRT warning when running Hailo8L model on Hailo8."""
+    combined = ""
+    if stdout:
+        combined += stdout.decode(errors='replace')
+    if stderr:
+        combined += stderr.decode(errors='replace')
+    return "warning" in combined.lower() and ("hailo8l" in combined.lower() or "8l" in combined.lower())
+
+
+# ============================================================================
+# Test Configuration
+# ============================================================================
+
 @pytest.fixture
 def pipeline():
     return {
         'name': 'face_recognition',
-        'module': 'hailo_apps.hailo_app_python.apps.face_recognition.face_recognition',
+        'module': 'hailo_apps.python.pipeline_apps.face_recognition.face_recognition',
         'script': 'hailo_apps/python/pipeline_apps/face_recognition/face_recognition.py',
         'cli': 'hailo-face-recon'
     }
@@ -45,9 +86,9 @@ run_methods = {
 @pytest.mark.parametrize('run_method_name', list(run_methods.keys()))
 def test_train(pipeline, run_method_name):
     test_name = 'test_train'
-    args = get_pipeline_args(suite='mode-train') 
+    args = get_pipeline_args(suite='mode-train')
     log_file_path = os.path.join(log_dir, f"{pipeline['name']}_{test_name}_{run_method_name}.log")
-    
+
     if run_method_name == 'module':
         stdout, stderr = run_methods[run_method_name](pipeline['module'], args, log_file_path)
     elif run_method_name == 'pythonpath':
@@ -56,7 +97,7 @@ def test_train(pipeline, run_method_name):
         stdout, stderr = run_methods[run_method_name](pipeline['cli'], args, log_file_path)
     else:
         pytest.fail(f"Unknown run method: {run_method_name}")
-    
+
     out_str = stdout.decode().lower() if stdout else ""
     err_str = stderr.decode().lower() if stderr else ""
     print(f"Completed: {test_name}, {pipeline['name']}, {run_method_name}: {out_str}")
@@ -70,9 +111,9 @@ def test_train(pipeline, run_method_name):
 @pytest.mark.parametrize('run_method_name', list(run_methods.keys()))
 def test_default(pipeline, run_method_name):
     test_name = 'test_default'
-    args = get_pipeline_args(suite='default') 
+    args = get_pipeline_args(suite='default')
     log_file_path = os.path.join(log_dir, f"{pipeline['name']}_{test_name}_{run_method_name}.log")
-    
+
     if run_method_name == 'module':
         stdout, stderr = run_methods[run_method_name](pipeline['module'], args, log_file_path)
     elif run_method_name == 'pythonpath':
@@ -81,7 +122,7 @@ def test_default(pipeline, run_method_name):
         stdout, stderr = run_methods[run_method_name](pipeline['cli'], args, log_file_path)
     else:
         pytest.fail(f"Unknown run method: {run_method_name}")
-    
+
     out_str = stdout.decode().lower() if stdout else ""
     err_str = stderr.decode().lower() if stderr else ""
     print(f"Completed: {test_name}, {pipeline['name']}, {run_method_name}: {out_str}")
@@ -97,7 +138,7 @@ def test_cli_usb(pipeline, run_method_name):
     test_name = 'test_cli_usb'
     args = get_pipeline_args(suite='usb_camera')
     log_file_path = os.path.join(log_dir, f"{pipeline['name']}_{test_name}_{run_method_name}.log")
-    
+
     if run_method_name == 'module':
         stdout, stderr = run_methods[run_method_name](pipeline['module'], args, log_file_path)
     elif run_method_name == 'pythonpath':
@@ -106,7 +147,7 @@ def test_cli_usb(pipeline, run_method_name):
         stdout, stderr = run_methods[run_method_name](pipeline['cli'], args, log_file_path)
     else:
         pytest.fail(f"Unknown run method: {run_method_name}")
-    
+
     out_str = stdout.decode().lower() if stdout else ""
     err_str = stderr.decode().lower() if stderr else ""
     print(f"Completed: {test_name}, {pipeline['name']}, {run_method_name}: {out_str}")
@@ -120,9 +161,9 @@ def test_cli_usb(pipeline, run_method_name):
 @pytest.mark.parametrize('run_method_name', list(run_methods.keys()))
 def test_delete(pipeline, run_method_name):
     test_name = 'test_delete'
-    args = get_pipeline_args(suite='mode-delete') 
+    args = get_pipeline_args(suite='mode-delete')
     log_file_path = os.path.join(log_dir, f"{pipeline['name']}_{test_name}_{run_method_name}.log")
-    
+
     if run_method_name == 'module':
         stdout, stderr = run_methods[run_method_name](pipeline['module'], args, log_file_path)
     elif run_method_name == 'pythonpath':
@@ -131,7 +172,7 @@ def test_delete(pipeline, run_method_name):
         stdout, stderr = '', ''  # can delete only once
     else:
         pytest.fail(f"Unknown run method: {run_method_name}")
-    
+
     out_str = stdout.decode().lower() if stdout else ""
     err_str = stderr.decode().lower() if stderr else ""
     print(f"Completed: {test_name}, {pipeline['name']}, {run_method_name}: {out_str}")
@@ -143,13 +184,16 @@ def test_delete(pipeline, run_method_name):
         logger.warning(f"Performance issue detected: QoS messages: {qos_count} total (>=100) for {pipeline['name']} ({run_method_name}) {test_name}")
 
 
-def run_hailo8l_model_on_hailo8_face_recon(model_name, extra_args=None):
-    """Helper function to run a Hailo8L model on Hailo 8 architecture for face recognition pipeline.
-    
+def run_hailo8l_models_on_hailo8_face_recon(model_names, extra_args=None):
+    """Helper to run Hailo8L models on Hailo 8 for face recognition pipeline.
+
+    Face recognition requires multiple models (detector + embedder), so all
+    model HEF paths are passed together.
+
     Args:
-        model_name: Name of the Hailo8L model to run
+        model_names: List of model names to pass together
         extra_args: Additional arguments to pass to the pipeline
-    
+
     Returns:
         tuple: (stdout, stderr, success)
     """
@@ -159,42 +203,42 @@ def run_hailo8l_model_on_hailo8_face_recon(model_name, extra_args=None):
         return b"", b"", False
 
     # Create logs directory
-    log_dir = "logs/h8l_on_h8_face_recon_tests"
-    os.makedirs(log_dir, exist_ok=True)
+    h8l_log_dir = "logs/h8l_on_h8_face_recon_tests"
+    os.makedirs(h8l_log_dir, exist_ok=True)
 
-    # Build full HEF path for Hailo8L model
-    hef_full_path = os.path.join(RESOURCES_ROOT_PATH_DEFAULT, "models", HAILO8L_ARCH, f"{model_name}.hef")
-    
-    # Prepare CLI arguments
-    args = ["--hef-path", hef_full_path]
+    # Build HEF paths for all models and pass them together
+    args = []
+    for model_name in model_names:
+        hef_full_path = os.path.join(RESOURCES_ROOT_PATH_DEFAULT, "models", HAILO8L_ARCH, f"{model_name}.hef")
+        args.extend(["--hef-path", hef_full_path])
     if extra_args:
         args.extend(extra_args)
 
-    # Create log file path
-    log_file_path = os.path.join(log_dir, f"face_recon_{model_name}.log")
+    model_label = "_".join(model_names)
+    log_file_path = os.path.join(h8l_log_dir, f"face_recon_{model_label}.log")
 
     try:
-        logger.info(f"Testing face recognition with Hailo8L model: {model_name} on Hailo 8")
+        logger.info(f"Testing face recognition with Hailo8L models: {model_names} on Hailo 8")
         stdout, stderr = run_pipeline_cli_with_args("hailo-face-recon", args, log_file_path)
 
         # Check for errors
         err_str = stderr.decode().lower() if stderr else ""
         success = "error" not in err_str and "traceback" not in err_str
-        
+
         # Check for HailoRT warning (expected for Hailo8L on Hailo8)
         has_warning = check_hailo8l_on_hailo8_warning(stdout, stderr)
         if not has_warning:
-            logger.warning(f"Expected HailoRT warning not found for {model_name} on Hailo 8")
-        
+            logger.warning(f"Expected HailoRT warning not found for {model_names} on Hailo 8")
+
         # Check for QoS performance issues
         has_qos_warning, qos_count = check_qos_performance_warning(stdout, stderr)
         if has_qos_warning:
-            logger.warning(f"Performance issue detected: QoS messages: {qos_count} total (>=100) for {model_name}")
-        
+            logger.warning(f"Performance issue detected: QoS messages: {qos_count} total (>=100) for {model_names}")
+
         return stdout, stderr, success
 
     except Exception as e:
-        logger.error(f"Exception while testing {model_name} on Hailo 8: {e}")
+        logger.error(f"Exception while testing {model_names} on Hailo 8: {e}")
         return b"", str(e).encode(), False
 
 
@@ -204,37 +248,22 @@ def test_hailo8l_models_on_hailo8_face_recon():
     if hailo_arch != HAILO8_ARCH:
         pytest.skip(f"Skipping Hailo-8L model test on {hailo_arch}")
 
-    # Define Hailo8L models that can be used with face recognition
-    h8l_models = ["scrfd_2.5g", "arcface_mobilefacenet_h8l"]
-    
-    logger.info(f"Running Hailo8L model test on Hailo 8 for face recognition pipeline")
-    
-    failed_models = []
-    
-    for model in h8l_models:
-        stdout, stderr, success = run_hailo8l_model_on_hailo8_face_recon(model)
-        
-        # Check for QoS performance issues
-        has_qos_warning, qos_count = check_qos_performance_warning(stdout, stderr)
-        if has_qos_warning:
-            logger.warning(f"Performance issue detected: QoS messages: {qos_count} total (>=100) for {model}")
-        
-        if not success:
-            failed_models.append({
-                "model": model,
-                "stderr": stderr.decode() if stderr else "",
-                "stdout": stdout.decode() if stdout else "",
-            })
-            logger.error(f"Failed to run {model} with face recognition")
-        else:
-            logger.info(f"Successfully ran {model} with face recognition")
+    # Face recognition requires both detector and embedder models together
+    h8l_models = ["scrfd_2.5g", "arcface_mobilefacenet"]
 
-    # Assert that all models passed
-    if failed_models:
-        failure_details = "\n".join(
-            [f"Model: {fail['model']}\nError: {fail['stderr']}\n" for fail in failed_models]
-        )
-        pytest.fail(f"Failed Hailo8L models for face recognition:\n{failure_details}")
+    logger.info("Running Hailo8L model test on Hailo 8 for face recognition pipeline")
+
+    stdout, stderr, success = run_hailo8l_models_on_hailo8_face_recon(h8l_models)
+
+    # Check for QoS performance issues
+    has_qos_warning, qos_count = check_qos_performance_warning(stdout, stderr)
+    if has_qos_warning:
+        logger.warning(f"Performance issue detected: QoS messages: {qos_count} total (>=100)")
+
+    assert success, (
+        f"Failed Hailo8L models for face recognition: {h8l_models}\n"
+        f"Error: {stderr.decode() if stderr else ''}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_gen_ai.py
+++ b/tests/test_gen_ai.py
@@ -14,6 +14,19 @@ TIMEOUT_DEFAULT = 60
 TIMEOUT_LONG = 120
 REPO_ROOT = Path(__file__).parent.parent
 
+# Skip all gen_ai tests unless running on Hailo-10H
+try:
+    from hailo_apps.python.core.common.installation_utils import detect_hailo_arch
+    from hailo_apps.python.core.common.defines import HAILO10H_ARCH
+    _is_hailo10h = detect_hailo_arch() == HAILO10H_ARCH
+except Exception:
+    _is_hailo10h = False
+
+pytestmark = pytest.mark.skipif(
+    not _is_hailo10h,
+    reason="Gen AI tests require Hailo-10H architecture",
+)
+
 def run_app_subprocess(module_path, args=None, input_text=None, timeout=TIMEOUT_DEFAULT, check_retcode=True):
     """
     Runs a python module as a subprocess.

--- a/tests/test_standalone_runner.py
+++ b/tests/test_standalone_runner.py
@@ -333,6 +333,13 @@ def generate_test_cases(
 
             for model in model_list:
                 for run_method in run_methods:
+                    # Skip CLI run method if app has no CLI entry point
+                    if run_method == "cli" and not app_def.cli:
+                        logger.debug(
+                            "Skipping CLI run method for %s (no CLI entry point defined)",
+                            app_name,
+                        )
+                        continue
                     for suite in suites:
                         test_cases.append(
                             {


### PR DESCRIPTION
## Summary

Four independent core/test fixes that were previously bundled with the
`hailooverlay_community` work on `community_apps` but are unrelated to
that plugin. Lifting them onto `dev` so they apply to every branch.

## Commits

### 1. `window_title` support + shutdown reliability
`hailo_apps/python/core/gstreamer/gstreamer_app.py`,
`hailo_apps/python/core/gstreamer/gstreamer_common.py`

- Add `window_title` attribute to `app_callback_class`;
  `display_user_data_frame` now uses it for the OpenCV display window
  title.
- Remove the bus signal watch *before* state transitions during
  `shutdown()` so callbacks don't fire mid-teardown.
- Replace fixed delays with `get_state()` waits and skip the redundant
  NULL transition when the pipeline is already there.

### 2. Pipeline rebuild reliability
`hailo_apps/python/core/gstreamer/gstreamer_app.py`

- Stop the old pipeline and terminate the display process *before*
  rebuilding, to avoid HailoRT device conflicts caused by inherited
  file descriptors.
- Replace the fixed wait with device-availability polling.
- Suppress GStreamer error messages while a rebuild is in flight to
  prevent spurious shutdowns.

### 3. `--run-duration <seconds>` flag
`hailo_apps/python/core/common/parser.py`

CLI flag that schedules a graceful shutdown after the given duration.
Enables reliable profiling with GST-Shark by ensuring clean EOS
propagation and trace flushing. No effect when unset.

### 4. Test suite fixes
`tests/test_face_recon.py`, `tests/test_standalone_runner.py`,
`tests/test_gen_ai.py`

- `test_face_recon.py` — update stale module imports, add missing helper
  functions, fix model name and multi-model logic.
- `test_standalone_runner.py` — skip the CLI run method for apps that
  have no CLI entry point (was producing 38 spurious "Permission denied"
  failures).
- `test_gen_ai.py` — skip gen_ai tests on non-Hailo-10H architectures.

## Conflict resolutions during cherry-pick from `community_apps`

Two semantic merges, both intent-preserving:

- **`gstreamer_app.py` shutdown path** — `dev` already has commit
  `12dd918` ("Fix signal.signal() thread safety in shutdown()") which
  guards `signal.signal(SIGINT, SIG_DFL)` with a `main_thread()` check.
  Commit 1 above adds `bus.remove_signal_watch()` adjacent to that line.
  Resolution: **keep the thread-safety guard AND add the bus-watch
  removal** — both intentions preserved.
- **`parser.py`** — both `dev` and the cherry-picked commit added new
  args after `--arch` (`--horizontal-mirror`/`--vertical-mirror` on
  dev, `--run-duration` on the cherry-pick). Resolution: **keep all
  three** — independent additions.

No conflicts in the test files.
