### PR TITLE
feat: add TAPPAS 5.2 support for Hailo-8/8L

### DIFF
--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -320,7 +320,7 @@ Before running hailo-apps, you need to install the Hailo runtime packages. The i
 **Note: Hailo Model Zoo GenAI** Is required only for Hailo-10H & GenAI use cases, like Hailo-Ollama, more details [Hailo Model Zoo GenAI](/hailo_apps/python/gen_ai_apps/hailo_ollama/README.md)
 
 > **Supported versions:**
-> - **Hailo-8 / Hailo-8L:** HailoRT 4.23, TAPPAS Core 5.1.0 & 5.2.0
+> - **Hailo-8 / Hailo-8L:** HailoRT 4.23, TAPPAS Core 5.1.0 & 5.2.0 & 5.3.0
 > - **Hailo-10H:** HailoRT 5.1.1, 5.2.0 & 5.3.0, TAPPAS Core 5.1.0, 5.2.0 & 5.3.0
 
 ---

--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -320,7 +320,7 @@ Before running hailo-apps, you need to install the Hailo runtime packages. The i
 **Note: Hailo Model Zoo GenAI** Is required only for Hailo-10H & GenAI use cases, like Hailo-Ollama, more details [Hailo Model Zoo GenAI](/hailo_apps/python/gen_ai_apps/hailo_ollama/README.md)
 
 > **Supported versions:**
-> - **Hailo-8 / Hailo-8L:** HailoRT 4.23, TAPPAS Core 5.1.0
+> - **Hailo-8 / Hailo-8L:** HailoRT 4.23, TAPPAS Core 5.1.0 & 5.2.0
 > - **Hailo-10H:** HailoRT 5.1.1, 5.2.0 & 5.3.0, TAPPAS Core 5.1.0, 5.2.0 & 5.3.0
 
 ---

--- a/hailo_apps/config/config.yaml
+++ b/hailo_apps/config/config.yaml
@@ -51,8 +51,8 @@ valid_versions:
 # The installer validates that the detected HailoRT+TAPPAS combo is in this list.
 
 valid_combinations:
-  hailo8: "4.23.0:5.1.0 4.23.0:5.2.0"
-  hailo8l: "4.23.0:5.1.0 4.23.0:5.2.0"
+  hailo8: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0"
+  hailo8l: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0"
   hailo10h: "5.1.1:5.1.0 5.2.0:5.2.0 5.3.0:5.3.0"
 
 #-------------------------------------------------------------------------------

--- a/hailo_apps/config/config.yaml
+++ b/hailo_apps/config/config.yaml
@@ -51,8 +51,8 @@ valid_versions:
 # The installer validates that the detected HailoRT+TAPPAS combo is in this list.
 
 valid_combinations:
-  hailo8: "4.23.0:5.1.0"
-  hailo8l: "4.23.0:5.1.0"
+  hailo8: "4.23.0:5.1.0 4.23.0:5.2.0"
+  hailo8l: "4.23.0:5.1.0 4.23.0:5.2.0"
   hailo10h: "5.1.1:5.1.0 5.2.0:5.2.0 5.3.0:5.3.0"
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Add 4.23.0:5.2.0 as a valid HailoRT+TAPPAS combination for hailo8 and hailo8l alongside the existing 4.23.0:5.1.0. Model Zoo remains v2.17.0 for all H8/H8L combinations.

Changes:
- config.yaml: add 4.23.0:5.2.0 to valid_combinations for hailo8/hailo8l
- installation.md: update supported versions documentation