### PR TITLE
Drone/hailotilecropper dynamic

### DIFF
--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/README.md
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/README.md
@@ -1,0 +1,23 @@
+# hailotilecropper_dynamic
+
+A GStreamer plugin that crops video tiles defined dynamically (per-buffer, by upstream
+pipeline elements) and/or statically (via element properties). Drop-in compatible
+with the standard `hailotileaggregator`.
+
+## Use case
+
+Set tile locations from application logic — e.g., add a tile that covers a tracked
+object, change tile count per frame, or feed a single full-frame tile when no
+detections are present.
+
+## Building & installing
+
+```bash
+source setup_env.sh
+hailo-compile-postprocess
+```
+
+## Status
+
+Implementation in progress. See
+`docs/superpowers/plans/2026-04-30-hailotilecropper-dynamic.md`.

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/README.md
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/README.md
@@ -1,23 +1,154 @@
 # hailotilecropper_dynamic
 
-A GStreamer plugin that crops video tiles defined dynamically (per-buffer, by upstream
-pipeline elements) and/or statically (via element properties). Drop-in compatible
-with the standard `hailotileaggregator`.
+A GStreamer plugin that crops video tiles whose locations come from upstream
+pipeline elements (per-buffer, dynamic) and/or from element properties (static).
+Drop-in compatible with TAPPAS `hailotileaggregator`.
 
-## Use case
+## When to use this
 
-Set tile locations from application logic — e.g., add a tile that covers a tracked
-object, change tile count per frame, or feed a single full-frame tile when no
-detections are present.
+The standard `hailotilecropper` only supports regular grids: `tiles-along-x-axis`,
+`tiles-along-y-axis`, and uniform overlap. Use `hailotilecropper_dynamic` when
+you need:
+
+- A tile around a specific tracked object every frame.
+- Variable tile count per frame based on application state.
+- A small fixed set of "always-on" tiles combined with dynamic ones.
+- To skip cropping entirely (bypass-only) when no tile is needed.
 
 ## Building & installing
+
+The plugin builds as part of the standard repo postprocess build:
 
 ```bash
 source setup_env.sh
 hailo-compile-postprocess
 ```
 
-## Status
+This installs `libgsthailotilecropper_dynamic.so` to GStreamer's plugin dir
+(`/usr/lib/x86_64-linux-gnu/gstreamer-1.0/` on a typical x86_64 system,
+resolved via `pkg-config --variable=pluginsdir gstreamer-1.0`). Verify:
 
-Implementation in progress. See
-`docs/superpowers/plans/2026-04-30-hailotilecropper-dynamic.md`.
+```bash
+rm -f ~/.cache/gstreamer-1.0/registry.x86_64.bin
+gst-inspect-1.0 hailotilecropper_dynamic
+```
+
+## Pad layout
+
+Inherited from `GstHailoBaseCropperDyn` (our private rename of TAPPAS's
+`GstHailoBaseCropper` — see Implementation notes below):
+
+| Pad name  | Direction | Role                                                |
+|-----------|-----------|-----------------------------------------------------|
+| `sink`    | sink      | Incoming video buffer.                              |
+| `src_0`   | source    | Bypass — original buffer with all tile sub-objects attached. Goes to `hailotileaggregator.sink_0`. |
+| `src_1`   | source    | Cropped — one buffer per tile, in tile-local coords. Goes to `hailotileaggregator.sink_1`. |
+
+## Properties
+
+| Property        | Type    | Default | Description                                                                                  |
+|-----------------|---------|---------|----------------------------------------------------------------------------------------------|
+| `tiles-static`  | string  | `""`    | Semicolon-separated list of `x,y,w,h` rectangles, normalized 0..1. Appended to dynamic tiles each frame. Out-of-range or unparseable entries are dropped with `GST_WARNING`. |
+| `allow-empty`   | boolean | `true`  | If `false`, log a warning when a buffer produces zero tiles.                                 |
+
+Inherited from the base class: `internal-offset`, `cropping-period`,
+`drop-uncropped-buffers`, `filter-streams`.
+
+## Attaching dynamic tiles from Python
+
+**Use `identity signal-handoffs=true` + `handoff` callback**, not pad probes.
+Python pad probes receive a non-writable buffer reference (refcount > 1), so
+`gst_buffer_add_hailo_meta()` silently fails. The `handoff` signal fires inside
+the `identity` chain function while the buffer is still writable.
+
+```python
+import hailo
+from gi.repository import Gst
+
+# Pipeline: ... ! identity name=tile_setter signal-handoffs=true ! hailotilecropper_dynamic ! ...
+def attach_tiles(_identity, buf):
+    roi = hailo.get_roi_from_buffer(buf)
+    # Add a tile around the tracked object's bbox (normalized 0..1):
+    roi.add_object(hailo.HailoTileROI(
+        hailo.HailoBBox(0.3, 0.4, 0.2, 0.2),
+        index=0, overlap_x_axis=0.0, overlap_y_axis=0.0, layer=0,
+        mode=hailo.SINGLE_SCALE,
+    ))
+
+pipeline.get_by_name("tile_setter").connect("handoff", attach_tiles)
+```
+
+The plugin reads all `HAILO_TILE` sub-objects from the parent ROI on each
+buffer, prepends them to the static-tile list, and crops accordingly.
+
+## Pipeline composition
+
+Standard pattern (matches the existing TAPPAS tiling app):
+
+```
+... ! identity name=tile_setter signal-handoffs=true !
+hailotilecropper_dynamic name=tc tiles-static="..." !
+  tc.src_0 ! queue ! agg.sink_0
+  tc.src_1 ! queue ! <inference> ! agg.sink_1
+hailotileaggregator name=agg flatten-detections=true iou-threshold=0.3 !
+agg.src ! hailooverlay ! videoconvert ! autovideosink
+```
+
+**Important:** put `hailooverlay` between `hailotileaggregator` and any
+caps-querying sink (`videoconvert`, `autovideosink`, etc.). The existing
+`hailotileaggregator` does not advertise caps on its `src` pad; pipelines
+that go directly from aggregator to a caps-querying element will crash with
+`gst_pad_query_accept_caps assertion`. `hailooverlay` mediates this and is
+also where bbox/label drawing happens.
+
+## Tests
+
+Build and run C++ unit tests:
+
+```bash
+cd hailo_apps/postprocess && \
+  meson setup --reconfigure build.release -Dbuild_tests=true && \
+  ninja -C build.release && \
+  meson test -C build.release --suite hailotilecropper_dynamic
+```
+
+Run Python E2E tests (the `conftest.py` preloads the freshest `.so` so tests
+work even before `hailo-compile-postprocess install` runs):
+
+```bash
+pytest hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e -v
+```
+
+## Example
+
+A runnable demo lives at `examples/tiling_dynamic_demo.py`:
+
+```bash
+DISPLAY=:0 python hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+```
+
+The demo walks a single dynamic tile across the frame using the identity-handoff
+pattern.
+
+## Implementation notes
+
+- **Bundled `GstHailoBaseCropperDyn` base class.** The plugin extends a private
+  copy of `GstHailoBaseCropper` from TAPPAS, renamed to `GstHailoBaseCropperDyn`
+  to avoid a GLib `g_type_register_static` conflict with `libgsthailotools.so`
+  (which registers the same type name internally). Without the rename, loading
+  both .so files in the same process produced
+  `cannot register existing type 'GstHailoBaseCropper'` warnings followed by
+  element-registration assertion failures.
+- **TAPPAS source vendored from v5.1.0** to match the installed runtime
+  (`pkg-config --modversion hailo-tappas-core` → `5.1.0`). v5.3.0 introduced
+  free functions `get_cv_matrices` / `crop_to_cv_matrices` that don't exist in
+  the installed v5.1.0 headers.
+- **Crop pad caps fallback.** Patched the bundled base cropper to fall back to
+  the incoming sink caps when the downstream peer of `src_1` returns ANY caps
+  (e.g. `fakesink`); upstream did not handle this case and triggered
+  `gst_caps_fixate(ANY)` assertion crashes.
+
+## License
+
+LGPL-2.1 (derived from TAPPAS — bundled `gsthailobasecropper.{cpp,hpp}` retain
+their original Hailo Technologies copyright headers).

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
@@ -1,55 +1,81 @@
-"""Demo: hailotilecropper_dynamic with a moving dynamic tile.
+"""Demo: hailotilecropper_dynamic with a moving dynamic tile (with display).
 
-Demonstrates:
-  - src_0 (bypass): full original frame flows through to the aggregator main input
-  - src_1 (crop):   one tile per frame around a moving region (dynamic)
-  - The tile bbox walks left-to-right and back across the frame
+What you see:
+    A source video (test pattern, RPi camera, USB cam, or file) plays in a
+    window with a red rectangle drawn at the tile's location each frame.
+    The rectangle walks left-to-right and back across the frame, showing
+    where the dynamic tile cropper is currently cropping.
 
-In a real pipeline you would replace the ``identity name=fake_inf`` element
-with a ``hailofilter`` running inference on the cropped tile.  The aggregator
-(``hailotileaggregator``) then merges the per-tile detections back into the
-full-frame coordinate space.
+Pipeline:
+    source → identity (attach HailoTileROI per buffer) → hailotilecropper_dynamic
+                                                              ↓ src_0 (bypass)
+                                                                  → videoconvert
+                                                                  → cairooverlay (draws tile box)
+                                                                  → autovideosink
+                                                              ↓ src_1 (cropped tile)
+                                                                  → fakesink
 
-Note on display: ``hailotileaggregator`` does not expose caps on its src pad
-in a way that ``videoconvert`` / ``autovideosink`` can negotiate.  The demo
-therefore uses ``fakesink`` for headless validation.  In production, wire the
-aggregator's src pad into a ``hailodisplay`` or a ``hailooverlay ! videoconvert
-! autovideosink`` chain that pulls caps from upstream elements.
+The bypass branch (src_0) is the one displayed because it carries the
+unmodified original frame; cairooverlay draws the tile box on top so you can
+see *where* the cropper is operating without depending on the aggregator +
+hailooverlay path (which requires real inference output to be useful).
+
+The cropped output (src_1) is consumed by fakesink — in a real pipeline this
+is where ``hailonet ! hailofilter`` runs inference on the tile and feeds the
+result into ``hailotileaggregator``. See
+``tests/e2e/test_e2e_aggregator_compat.py`` for the full aggregator wiring.
+
+Works on x86_64 and aarch64 (RPi). The plugin .so is preloaded via the path
+returned by ``pkg-config --variable=pluginsdir gstreamer-1.0`` so the demo
+doesn't hardcode any multiarch directory.
+
+Usage:
+    DISPLAY=:0 python tiling_dynamic_demo.py                            # videotestsrc (default)
+    DISPLAY=:0 python tiling_dynamic_demo.py --input libcamera          # RPi CSI camera
+    DISPLAY=:0 python tiling_dynamic_demo.py --input /dev/video0        # USB webcam
+    DISPLAY=:0 python tiling_dynamic_demo.py --input /path/to/video.mp4 # file
+    python tiling_dynamic_demo.py --frames 60 --no-display              # headless smoke test
 
 Press Ctrl-C to stop.
-
-The demo prefers the freshly built .so under build.release/ when present (so it
-runs before ``sudo hailo-compile-postprocess install`` updates the system .so).
-
-Usage::
-
-    python examples/tiling_dynamic_demo.py
-    python examples/tiling_dynamic_demo.py --frames 300
-    python examples/tiling_dynamic_demo.py --width 320 --height 240
 """
 import argparse
 import ctypes
 import pathlib
+import subprocess
 import sys
 
 # ---------------------------------------------------------------------------
-# Preload the freshest plugin .so before GStreamer init — same approach as
-# tests/e2e/conftest.py.  Needed when the system-installed .so is stale.
+# Plugin .so preload — works on any arch via pkg-config.
+#
+# GStreamer caches its plugin registry, so a freshly-built .so under
+# build.release/ may not be picked up before ``hailo-compile-postprocess
+# install`` updates the system copy. Preloading forces the library into the
+# process so Gst.init resolves the element regardless of registry state.
 # ---------------------------------------------------------------------------
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]  # …/hailo-apps-infra
 _BUILD_SO = (
     _REPO_ROOT / "hailo_apps" / "postprocess" / "build.release" / "cpp"
     / "libgsthailotilecropper_dynamic.so"
 )
-_SYS_SO = pathlib.Path(
-    "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthailotilecropper_dynamic.so"
-)
+
+
+def _system_plugin_so() -> pathlib.Path | None:
+    """Locate the installed plugin via pkg-config (multiarch-portable)."""
+    try:
+        pluginsdir = subprocess.check_output(
+            ["pkg-config", "--variable=pluginsdir", "gstreamer-1.0"],
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return pathlib.Path(pluginsdir) / "libgsthailotilecropper_dynamic.so" if pluginsdir else None
 
 
 def _preferred_so() -> pathlib.Path | None:
-    if _BUILD_SO.exists() and _SYS_SO.exists():
-        return _BUILD_SO if _BUILD_SO.stat().st_mtime > _SYS_SO.stat().st_mtime else _SYS_SO
-    return _BUILD_SO if _BUILD_SO.exists() else (_SYS_SO if _SYS_SO.exists() else None)
+    """Prefer the freshest of the local build vs. system-installed .so."""
+    sys_so = _system_plugin_so()
+    candidates = [p for p in (_BUILD_SO, sys_so) if p is not None and p.exists()]
+    return max(candidates, key=lambda p: p.stat().st_mtime) if candidates else None
 
 
 _so = _preferred_so()
@@ -65,32 +91,100 @@ import hailo  # noqa: E402
 
 Gst.init(None)
 
+
 # ---------------------------------------------------------------------------
-# Dynamic tile callback
+# Source-element selection (mirrors hailo_apps' SOURCE_PIPELINE conventions)
 # ---------------------------------------------------------------------------
 
-def make_attach_dynamic_tile():
-    """Return a handoff callback that attaches a single dynamic tile per buffer.
+def build_source_element(input_src: str, width: int, height: int, frames: int) -> str:
+    """Return a GStreamer source chain ending in ``video/x-raw,format=RGB,WxH``."""
+    common_caps = f"video/x-raw,format=RGB,width={width},height={height}"
+    num_buffers = f" num-buffers={frames}" if frames > 0 else ""
 
-    Walks the tile bbox left-to-right and back across the frame.  In a real
-    app this is where you'd plug in tracker output.
+    if input_src == "test":
+        return (
+            f"videotestsrc is-live=false{num_buffers} ! "
+            f"videoconvert ! {common_caps},framerate=30/1"
+        )
+    if input_src == "libcamera":
+        # RPi CSI camera via libcamera. Requires libcamera + gstreamer1.0-libcamera.
+        return (
+            f"libcamerasrc ! video/x-raw,framerate=30/1 ! "
+            f"videoscale ! videoconvert ! {common_caps}"
+        )
+    if input_src.startswith("/dev/video"):
+        # V4L2 device (USB webcam). MJPEG via decodebin handles most webcams.
+        return (
+            f"v4l2src device={input_src}{num_buffers} ! image/jpeg,framerate=30/1 ! "
+            f"decodebin ! videoscale ! videoconvert ! {common_caps}"
+        )
+    # Anything else — treat as a file path.
+    return (
+        f"filesrc location=\"{input_src}\" ! decodebin ! "
+        f"videoscale ! videoconvert ! {common_caps}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tile state shared between the cropper-handoff and the cairooverlay draw.
+# ---------------------------------------------------------------------------
+
+class TileWalker:
+    """Per-frame tile generator. Walks a 0.4-wide tile back and forth."""
+
+    TILE_W = 0.4
+    TILE_H = 0.4
+    TILE_Y = 0.2
+    X_MIN = 0.1
+    X_MAX = 0.5  # so left edge stays in [0.1, 0.5] → tile fully in frame
+    PHASE_STEP = 0.05
+
+    def __init__(self):
+        self._phase = 0.0
+        self._frames = 0
+        self.x = self.X_MIN
+
+    def step(self) -> float:
+        """Advance one frame. Returns the new tile x (left edge, normalized)."""
+        self.x = self.X_MIN + (self.X_MAX - self.X_MIN) * abs((self._phase % 2.0) - 1.0)
+        self._phase += self.PHASE_STEP
+        self._frames += 1
+        if self._frames % 30 == 0:
+            print(f"  frame {self._frames:5d}  tile x={self.x:.3f}", flush=True)
+        return self.x
+
+
+# ---------------------------------------------------------------------------
+# Pipeline callbacks
+# ---------------------------------------------------------------------------
+
+def make_attach_dynamic_tile(walker: TileWalker):
+    """Handoff that attaches one moving tile per buffer.
+
+    In a real app this is where tracker / detector output goes.
     """
-    state = {"phase": 0.0, "frames": 0}
-
     def handoff(_identity, buf):
+        x = walker.step()
         roi = hailo.get_roi_from_buffer(buf)
-        # x oscillates between 0.1 and 0.5 so the 0.4-wide tile stays in frame
-        x = 0.1 + 0.4 * abs((state["phase"] % 2.0) - 1.0)
         roi.add_object(hailo.HailoTileROI(
-            hailo.HailoBBox(x, 0.2, 0.4, 0.4),
+            hailo.HailoBBox(x, walker.TILE_Y, walker.TILE_W, walker.TILE_H),
             0, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
         ))
-        state["phase"] += 0.05
-        state["frames"] += 1
-        if state["frames"] % 30 == 0:
-            print(f"  frame {state['frames']:5d}  tile x={x:.3f}", flush=True)
-
     return handoff
+
+
+def make_draw_tile_box(walker: TileWalker, frame_w: int, frame_h: int):
+    """cairooverlay draw handler — paints the current tile rectangle on the frame."""
+    def draw(_overlay, ctx, _ts, _dur):
+        x = walker.x * frame_w
+        y = walker.TILE_Y * frame_h
+        w = walker.TILE_W * frame_w
+        h = walker.TILE_H * frame_h
+        ctx.set_source_rgb(1.0, 0.2, 0.2)  # red
+        ctx.set_line_width(3.0)
+        ctx.rectangle(x, y, w, h)
+        ctx.stroke()
+    return draw
 
 
 # ---------------------------------------------------------------------------
@@ -98,30 +192,47 @@ def make_attach_dynamic_tile():
 # ---------------------------------------------------------------------------
 
 def main():
-    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--input", default="test",
+                   help="Source: 'test' (videotestsrc, default), 'libcamera' (RPi CSI), "
+                        "'/dev/videoN' (V4L2), or path to a video file.")
     p.add_argument("--width", type=int, default=640)
     p.add_argument("--height", type=int, default=480)
     p.add_argument("--frames", type=int, default=0,
-                   help="Number of frames to process (0 = run until Ctrl-C)")
+                   help="Number of frames to process (0 = run until Ctrl-C). "
+                        "Only honoured for 'test' and V4L2 sources.")
+    p.add_argument("--no-display", action="store_true",
+                   help="Use fakesink instead of autovideosink (headless smoke test).")
     args = p.parse_args()
 
-    num_buffers = f"num-buffers={args.frames}" if args.frames > 0 else ""
+    walker = TileWalker()
+    source = build_source_element(args.input, args.width, args.height, args.frames)
+    primary_sink = (
+        "fakesink sync=false async=false"
+        if args.no_display
+        else "videoconvert ! autovideosink sync=false"
+    )
 
     pipeline_str = (
-        f"videotestsrc is-live=false {num_buffers} ! "
-        f"videoconvert ! "
-        f"video/x-raw,format=RGB,width={args.width},height={args.height},framerate=30/1 ! "
+        f"{source} ! "
         "identity name=tile_setter signal-handoffs=true ! "
-        "hailotilecropper_dynamic name=tc "
-        "tc.src_0 ! queue ! agg.sink_0 "
-        "tc.src_1 ! queue ! identity name=fake_inf signal-handoffs=true ! agg.sink_1 "
-        "hailotileaggregator name=agg flatten-detections=true iou-threshold=0.3 "
-        "agg.src ! fakesink sync=false async=false"
+        "hailotilecropper_dynamic name=tc internal-offset=true "
+        # Bypass branch (src_0): the original frame, displayed with a tile-box overlay.
+        f"tc.src_0 ! queue ! videoconvert ! cairooverlay name=tile_overlay ! {primary_sink} "
+        # Cropped branch (src_1): consume so the cropper has somewhere to push.
+        # In a real pipeline this is hailonet ! hailofilter ! agg.sink_1.
+        "tc.src_1 ! queue ! fakesink sync=false async=false"
     )
     print(f"Pipeline:\n  {pipeline_str}\n", flush=True)
 
     pipe = Gst.parse_launch(pipeline_str)
-    pipe.get_by_name("tile_setter").connect("handoff", make_attach_dynamic_tile())
+    pipe.get_by_name("tile_setter").connect("handoff", make_attach_dynamic_tile(walker))
+    pipe.get_by_name("tile_overlay").connect(
+        "draw", make_draw_tile_box(walker, args.width, args.height)
+    )
 
     loop = GLib.MainLoop()
     bus = pipe.get_bus()

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
@@ -1,57 +1,50 @@
-"""Demo: hailotilecropper_dynamic with a moving dynamic tile (with display).
+"""Demo: hailotilecropper_dynamic on top of GStreamerTilingApp.
 
-What you see:
-    A source video (test pattern, RPi camera, USB cam, or file) plays in a
-    window with a red rectangle drawn at the tile's location each frame.
-    The rectangle walks left-to-right and back across the frame, showing
-    where the dynamic tile cropper is currently cropping.
+Reuses the standard tiling app from ``hailo_apps`` and swaps the regular
+``hailotilecropper`` for the community ``hailotilecropper_dynamic`` element.
+Everything else — input source (``--input rpi/usb/file/...``), HEF resolution,
+inference pipeline, hailooverlay + display sink, FPS counter — is inherited
+from the framework. The only added Python is a per-buffer ``handoff`` that
+attaches a moving HailoTileROI so the dynamic cropper has a tile to crop.
 
-Pipeline:
-    source → identity (attach HailoTileROI per buffer) → hailotilecropper_dynamic
-                                                              ↓ src_0 (bypass)
-                                                                  → videoconvert
-                                                                  → cairooverlay (draws tile box)
-                                                                  → autovideosink
-                                                              ↓ src_1 (cropped tile)
-                                                                  → fakesink
+Pipeline (inherited shape):
 
-The bypass branch (src_0) is the one displayed because it carries the
-unmodified original frame; cairooverlay draws the tile box on top so you can
-see *where* the cropper is operating without depending on the aggregator +
-hailooverlay path (which requires real inference output to be useful).
+    source → identity (attach moving tile)
+           → hailotilecropper_dynamic
+                ├─ src_0 (bypass)  → agg.sink_0
+                └─ src_1 (cropped) → INFERENCE_PIPELINE → agg.sink_1
+           → hailotileaggregator → user_callback → hailooverlay → display
 
-The cropped output (src_1) is consumed by fakesink — in a real pipeline this
-is where ``hailonet ! hailofilter`` runs inference on the tile and feeds the
-result into ``hailotileaggregator``. See
-``tests/e2e/test_e2e_aggregator_compat.py`` for the full aggregator wiring.
+Why this matters: the regular cropper runs inference on every cell of a
+fixed grid; here inference runs only on the dynamic tile, so all NPU budget
+goes to the region the application cares about.
 
-Works on x86_64 and aarch64 (RPi). The plugin .so is preloaded via the path
-returned by ``pkg-config --variable=pluginsdir gstreamer-1.0`` so the demo
-doesn't hardcode any multiarch directory.
+Works on x86_64 and aarch64 (RPi). The plugin .so is preloaded via
+``pkg-config --variable=pluginsdir gstreamer-1.0`` so the demo doesn't
+hardcode a multiarch directory.
 
-Usage:
-    DISPLAY=:0 python tiling_dynamic_demo.py                            # videotestsrc (default)
-    DISPLAY=:0 python tiling_dynamic_demo.py --input libcamera          # RPi CSI camera
+Usage::
+
+    DISPLAY=:0 python tiling_dynamic_demo.py --input test               # videotestsrc
+    DISPLAY=:0 python tiling_dynamic_demo.py --input rpi                # RPi CSI camera
     DISPLAY=:0 python tiling_dynamic_demo.py --input /dev/video0        # USB webcam
     DISPLAY=:0 python tiling_dynamic_demo.py --input /path/to/video.mp4 # file
-    python tiling_dynamic_demo.py --frames 60 --no-display              # headless smoke test
 
 Press Ctrl-C to stop.
-"""
-import argparse
-import ctypes
-import pathlib
-import subprocess
-import sys
 
+The tile-grid flags inherited from the parent app (``--tiles-x``,
+``--tiles-y``, ``--multi-scale``, ``--scale-levels``) are ignored — the
+dynamic cropper has no grid.
+"""
 # ---------------------------------------------------------------------------
-# Plugin .so preload — works on any arch via pkg-config.
-#
-# GStreamer caches its plugin registry, so a freshly-built .so under
-# build.release/ may not be picked up before ``hailo-compile-postprocess
-# install`` updates the system copy. Preloading forces the library into the
-# process so Gst.init resolves the element regardless of registry state.
+# Plugin .so preload — must run BEFORE any hailo_apps import so that
+# GstHailoBaseCropperDyn registers before libgsthailotools.so registers
+# upstream's GstHailoBaseCropper.  Multiarch-portable via pkg-config.
 # ---------------------------------------------------------------------------
+import ctypes  # noqa: E402
+import pathlib  # noqa: E402
+import subprocess  # noqa: E402
+
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]  # …/hailo-apps-infra
 _BUILD_SO = (
     _REPO_ROOT / "hailo_apps" / "postprocess" / "build.release" / "cpp"
@@ -59,7 +52,7 @@ _BUILD_SO = (
 )
 
 
-def _system_plugin_so() -> pathlib.Path | None:
+def _system_plugin_so() -> "pathlib.Path | None":
     """Locate the installed plugin via pkg-config (multiarch-portable)."""
     try:
         pluginsdir = subprocess.check_output(
@@ -71,7 +64,7 @@ def _system_plugin_so() -> pathlib.Path | None:
     return pathlib.Path(pluginsdir) / "libgsthailotilecropper_dynamic.so" if pluginsdir else None
 
 
-def _preferred_so() -> pathlib.Path | None:
+def _preferred_so() -> "pathlib.Path | None":
     """Prefer the freshest of the local build vs. system-installed .so."""
     sys_so = _system_plugin_so()
     candidates = [p for p in (_BUILD_SO, sys_so) if p is not None and p.exists()]
@@ -83,181 +76,201 @@ if _so is not None:
     print(f"Preloading: {_so}", flush=True)
     ctypes.CDLL(str(_so), mode=ctypes.RTLD_GLOBAL)
 
-import gi  # noqa: E402
 
-gi.require_version("Gst", "1.0")
-from gi.repository import Gst, GLib  # noqa: E402
+# ---------------------------------------------------------------------------
+# Imports — after the preload above.
+# ---------------------------------------------------------------------------
 import hailo  # noqa: E402
 
-Gst.init(None)
+from hailo_apps.python.core.common.hailo_logger import get_logger  # noqa: E402
+from hailo_apps.python.core.gstreamer.gstreamer_app import (  # noqa: E402
+    app_callback_class,
+    dummy_callback,
+)
+from hailo_apps.python.core.gstreamer.gstreamer_helper_pipelines import (  # noqa: E402
+    DISPLAY_PIPELINE,
+    INFERENCE_PIPELINE,
+    QUEUE,
+    USER_CALLBACK_PIPELINE,
+)
+from hailo_apps.python.pipeline_apps.tiling.tiling_pipeline import (  # noqa: E402
+    GStreamerTilingApp,
+)
+
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Source-element selection (mirrors hailo_apps' SOURCE_PIPELINE conventions)
+# Helper: dynamic-tile-cropper pipeline fragment.
+# Mirrors hailo_apps' TILE_CROPPER_PIPELINE but with hailotilecropper_dynamic
+# and an upstream identity-handoff for per-buffer tile injection.
 # ---------------------------------------------------------------------------
 
-def build_source_element(input_src: str, width: int, height: int, frames: int) -> str:
-    """Return a GStreamer source chain ending in ``video/x-raw,format=RGB,WxH``."""
-    common_caps = f"video/x-raw,format=RGB,width={width},height={height}"
-    num_buffers = f" num-buffers={frames}" if frames > 0 else ""
+def DYNAMIC_TILE_CROPPER_PIPELINE(
+    inner_pipeline: str,
+    name: str = "dyn_tile_cropper",
+    internal_offset: bool = True,
+    iou_threshold: float = 0.3,
+    border_threshold: float = 0.0,
+    tiles_static: str = "",
+) -> str:
+    """Build a `tile_setter ! cropper [tee] aggregator` chain.
 
-    if input_src == "test":
-        return (
-            f"videotestsrc is-live=false{num_buffers} ! "
-            f"videoconvert ! {common_caps},framerate=30/1"
-        )
-    if input_src == "libcamera":
-        # RPi CSI camera via libcamera. Requires libcamera + gstreamer1.0-libcamera.
-        return (
-            f"libcamerasrc ! video/x-raw,framerate=30/1 ! "
-            f"videoscale ! videoconvert ! {common_caps}"
-        )
-    if input_src.startswith("/dev/video"):
-        # V4L2 device (USB webcam). MJPEG via decodebin handles most webcams.
-        return (
-            f"v4l2src device={input_src}{num_buffers} ! image/jpeg,framerate=30/1 ! "
-            f"decodebin ! videoscale ! videoconvert ! {common_caps}"
-        )
-    # Anything else — treat as a file path.
+    Same I/O contract as `TILE_CROPPER_PIPELINE` — drops in where that
+    helper would be used. The bypass branch carries the original frame to
+    `agg.sink_0`; the cropped branch is fed through ``inner_pipeline``
+    (typically ``INFERENCE_PIPELINE(...)``) and joins at ``agg.sink_1``.
+
+    Connect a Python handoff to the element named ``{name}_tile_setter`` to
+    attach `HailoTileROI` sub-objects per buffer.
+    """
+    border = (
+        f"border-threshold={str(border_threshold).lower()} "
+        if border_threshold else ""
+    )
+    static_prop = f'tiles-static="{tiles_static}" ' if tiles_static else ""
     return (
-        f"filesrc location=\"{input_src}\" ! decodebin ! "
-        f"videoscale ! videoconvert ! {common_caps}"
+        f"identity name={name}_tile_setter signal-handoffs=true ! "
+        f"{QUEUE(name=f'{name}_input_q')} ! "
+        f"hailotilecropper_dynamic name={name}_cropper "
+        f"internal-offset={str(internal_offset).lower()} {static_prop}"
+        f"hailotileaggregator name={name}_agg "
+        f"flatten-detections=true iou-threshold={iou_threshold} {border}"
+        # bypass branch
+        f"{name}_cropper. ! {QUEUE(name=f'{name}_bypass_q')} ! {name}_agg. "
+        # inference branch — capsfilter pins the crop output format to RGB so
+        # the cropper's src_1 caps negotiation doesn't fixate on a YUV format
+        # (which mismatches the bypass/sink format and trips the cropper's
+        # in_format == out_format guard).
+        f"{name}_cropper. ! video/x-raw,format=RGB ! {inner_pipeline} ! {name}_agg. "
+        # aggregator output
+        f"{name}_agg. ! {QUEUE(name=f'{name}_output_q')}"
     )
 
 
 # ---------------------------------------------------------------------------
-# Tile state shared between the cropper-handoff and the cairooverlay draw.
+# Subclass: same as GStreamerTilingApp, with hailotilecropper_dynamic in the
+# pipeline string. Everything else (source, inference, display) is inherited.
+# ---------------------------------------------------------------------------
+
+CROPPER_NAME = "dyn_tc"
+
+
+class GStreamerDynamicTilingApp(GStreamerTilingApp):
+    """Tiling app that uses the community dynamic cropper instead of a fixed grid."""
+
+    def get_pipeline_string(self) -> str:
+        source_pipeline = self.get_source_pipeline()
+
+        detection_pipeline = INFERENCE_PIPELINE(
+            hef_path=self.hef_path,
+            post_process_so=self.post_process_so,
+            post_function_name=self.post_function,
+            batch_size=self.batch_size,
+            config_json=self.labels_json,
+        )
+
+        tile_cropper_pipeline = DYNAMIC_TILE_CROPPER_PIPELINE(
+            detection_pipeline,
+            name=CROPPER_NAME,
+            internal_offset=True,
+            iou_threshold=self.iou_threshold,
+        )
+
+        user_callback_pipeline = USER_CALLBACK_PIPELINE()
+
+        display_pipeline = DISPLAY_PIPELINE(
+            video_sink=self.video_sink,
+            sync=self.sync,
+            show_fps=self.show_fps,
+        )
+
+        return (
+            f"{source_pipeline} ! "
+            f"{tile_cropper_pipeline} ! "
+            f"{user_callback_pipeline} ! "
+            f"{display_pipeline}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-frame: walk a single tile across the frame.
 # ---------------------------------------------------------------------------
 
 class TileWalker:
-    """Per-frame tile generator. Walks a 0.4-wide tile back and forth."""
+    """Returns a moving 0.4-wide tile each frame; left edge bounces in [0.1, 0.5]."""
 
     TILE_W = 0.4
     TILE_H = 0.4
     TILE_Y = 0.2
     X_MIN = 0.1
-    X_MAX = 0.5  # so left edge stays in [0.1, 0.5] → tile fully in frame
-    PHASE_STEP = 0.05
+    X_MAX = 0.5
+    PHASE_STEP = 0.02
 
     def __init__(self):
         self._phase = 0.0
         self._frames = 0
-        self.x = self.X_MIN
 
-    def step(self) -> float:
-        """Advance one frame. Returns the new tile x (left edge, normalized)."""
-        self.x = self.X_MIN + (self.X_MAX - self.X_MIN) * abs((self._phase % 2.0) - 1.0)
+    def step(self) -> "hailo.HailoTileROI":
+        x = self.X_MIN + (self.X_MAX - self.X_MIN) * abs((self._phase % 2.0) - 1.0)
         self._phase += self.PHASE_STEP
         self._frames += 1
         if self._frames % 30 == 0:
-            print(f"  frame {self._frames:5d}  tile x={self.x:.3f}", flush=True)
-        return self.x
-
-
-# ---------------------------------------------------------------------------
-# Pipeline callbacks
-# ---------------------------------------------------------------------------
-
-def make_attach_dynamic_tile(walker: TileWalker):
-    """Handoff that attaches one moving tile per buffer.
-
-    In a real app this is where tracker / detector output goes.
-    """
-    def handoff(_identity, buf):
-        x = walker.step()
-        roi = hailo.get_roi_from_buffer(buf)
-        roi.add_object(hailo.HailoTileROI(
-            hailo.HailoBBox(x, walker.TILE_Y, walker.TILE_W, walker.TILE_H),
+            print(f"  frame {self._frames:5d}  tile x={x:.3f}", flush=True)
+        return hailo.HailoTileROI(
+            hailo.HailoBBox(x, self.TILE_Y, self.TILE_W, self.TILE_H),
             0, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
-        ))
+        )
+
+
+def make_tile_handoff(walker: TileWalker):
+    def handoff(_identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        roi.add_object(walker.step())
     return handoff
 
 
-def make_draw_tile_box(walker: TileWalker, frame_w: int, frame_h: int):
-    """cairooverlay draw handler — paints the current tile rectangle on the frame."""
-    def draw(_overlay, ctx, _ts, _dur):
-        x = walker.x * frame_w
-        y = walker.TILE_Y * frame_h
-        w = walker.TILE_W * frame_w
-        h = walker.TILE_H * frame_h
-        ctx.set_source_rgb(1.0, 0.2, 0.2)  # red
-        ctx.set_line_width(3.0)
-        ctx.rectangle(x, y, w, h)
-        ctx.stroke()
-    return draw
+# ---------------------------------------------------------------------------
+# User callback: log the merged detections per frame (optional but nice).
+# ---------------------------------------------------------------------------
+
+class UserData(app_callback_class):
+    pass
+
+
+def app_callback(_pad, buffer, user_data):
+    if buffer is None:
+        return
+    dets = list(
+        hailo.get_roi_from_buffer(buffer).get_objects_typed(hailo.HAILO_DETECTION)
+    )
+    if dets:
+        labels = ", ".join(f"{d.get_label()}@{d.get_confidence():.2f}" for d in dets[:5])
+        print(f"  frame {user_data.get_count():5d}  detections=[{labels}]", flush=True)
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
-def main():
-    p = argparse.ArgumentParser(
-        description=__doc__.splitlines()[0],
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    p.add_argument("--input", default="test",
-                   help="Source: 'test' (videotestsrc, default), 'libcamera' (RPi CSI), "
-                        "'/dev/videoN' (V4L2), or path to a video file.")
-    p.add_argument("--width", type=int, default=640)
-    p.add_argument("--height", type=int, default=480)
-    p.add_argument("--frames", type=int, default=0,
-                   help="Number of frames to process (0 = run until Ctrl-C). "
-                        "Only honoured for 'test' and V4L2 sources.")
-    p.add_argument("--no-display", action="store_true",
-                   help="Use fakesink instead of autovideosink (headless smoke test).")
-    args = p.parse_args()
+def main() -> None:
+    logger.info("Starting hailotilecropper_dynamic demo (on top of GStreamerTilingApp)")
 
+    user_data = UserData()
+    app = GStreamerDynamicTilingApp(app_callback, user_data)
+
+    # Wire dynamic-tile injection. Must happen after the pipeline has been
+    # built (in the parent's __init__) and before app.run() flips state.
     walker = TileWalker()
-    source = build_source_element(args.input, args.width, args.height, args.frames)
-    primary_sink = (
-        "fakesink sync=false async=false"
-        if args.no_display
-        else "videoconvert ! autovideosink sync=false"
-    )
+    tile_setter = app.pipeline.get_by_name(f"{CROPPER_NAME}_tile_setter")
+    if tile_setter is None:
+        raise RuntimeError(
+            f"could not find '{CROPPER_NAME}_tile_setter' in the pipeline — "
+            "DYNAMIC_TILE_CROPPER_PIPELINE wiring is wrong"
+        )
+    tile_setter.connect("handoff", make_tile_handoff(walker))
 
-    pipeline_str = (
-        f"{source} ! "
-        "identity name=tile_setter signal-handoffs=true ! "
-        "hailotilecropper_dynamic name=tc internal-offset=true "
-        # Bypass branch (src_0): the original frame, displayed with a tile-box overlay.
-        f"tc.src_0 ! queue ! videoconvert ! cairooverlay name=tile_overlay ! {primary_sink} "
-        # Cropped branch (src_1): consume so the cropper has somewhere to push.
-        # In a real pipeline this is hailonet ! hailofilter ! agg.sink_1.
-        "tc.src_1 ! queue ! fakesink sync=false async=false"
-    )
-    print(f"Pipeline:\n  {pipeline_str}\n", flush=True)
-
-    pipe = Gst.parse_launch(pipeline_str)
-    pipe.get_by_name("tile_setter").connect("handoff", make_attach_dynamic_tile(walker))
-    pipe.get_by_name("tile_overlay").connect(
-        "draw", make_draw_tile_box(walker, args.width, args.height)
-    )
-
-    loop = GLib.MainLoop()
-    bus = pipe.get_bus()
-    bus.add_signal_watch()
-
-    def on_msg(_b, msg):
-        t = msg.type
-        if t == Gst.MessageType.EOS:
-            print("EOS received — stopping.", flush=True)
-            loop.quit()
-        elif t == Gst.MessageType.ERROR:
-            err, dbg = msg.parse_error()
-            print(f"ERROR: {err.message}\n{dbg}", file=sys.stderr)
-            loop.quit()
-    bus.connect("message", on_msg)
-
-    pipe.set_state(Gst.State.PLAYING)
-    print("Pipeline running — press Ctrl-C to stop.\n", flush=True)
-    try:
-        loop.run()
-    except KeyboardInterrupt:
-        print("\nInterrupted.", flush=True)
-    finally:
-        pipe.set_state(Gst.State.NULL)
-    print("Pipeline stopped.", flush=True)
+    app.run()
 
 
 if __name__ == "__main__":

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
@@ -4,20 +4,49 @@ Reuses the standard tiling app from ``hailo_apps`` and swaps the regular
 ``hailotilecropper`` for the community ``hailotilecropper_dynamic`` element.
 Everything else — input source (``--input rpi/usb/file/...``), HEF resolution,
 inference pipeline, hailooverlay + display sink, FPS counter — is inherited
-from the framework. The only added Python is a per-buffer ``handoff`` that
-attaches a moving HailoTileROI so the dynamic cropper has a tile to crop.
+from the framework.
+
+Static + dynamic contrast
+-------------------------
+Two tiles run side-by-side every frame, so the same scene is inferred twice
+at different resolutions:
+
+  * **Static tile** — a *large* always-on rectangle on the left half of the
+    frame (``--static-tiles`` default ``"0.0,0.05,0.5,0.9"``). It covers a
+    wide area, so when ``internal-offset`` rescales it to the model's
+    expected input (e.g. 640×480 for the default HEF) every person inside
+    occupies only a small fraction of the tile pixels. **Lower per-object
+    detail → lower confidence.**
+
+  * **Dynamic tile** — a *small* moving rectangle (0.2 × 0.3) attached
+    per-frame via the identity-handoff pattern. Walks left-to-right and
+    back. Because it is smaller, internal-offset upscales fewer source
+    pixels by a larger factor, so each person inside occupies a larger
+    fraction of the model input. **Higher per-object detail → higher
+    confidence whenever an object is in the dynamic tile.**
+
+Watch the confidence reported by the user callback as the dynamic tile
+sweeps across the frame: persons that show up only in the static tile
+report lower confidences than the same persons once the dynamic tile lands
+on them. ``hailotileaggregator`` does cross-tile NMS so the higher-
+confidence (dynamic-tile) detection wins where the two overlap.
+
+Pass ``--static-tiles ""`` to disable the static tile and run only the
+dynamic one.
 
 Pipeline (inherited shape):
 
     source → identity (attach moving tile)
-           → hailotilecropper_dynamic
-                ├─ src_0 (bypass)  → agg.sink_0
-                └─ src_1 (cropped) → INFERENCE_PIPELINE → agg.sink_1
+           → hailotilecropper_dynamic [tiles-static="…"]
+                ├─ src_0 (bypass)        → agg.sink_0
+                └─ src_1 (cropped tiles) → INFERENCE_PIPELINE → agg.sink_1
+                       (one cropped buffer per static + dynamic tile)
            → hailotileaggregator → user_callback → hailooverlay → display
 
-Why this matters: the regular cropper runs inference on every cell of a
-fixed grid; here inference runs only on the dynamic tile, so all NPU budget
-goes to the region the application cares about.
+Why this matters: a regular cropper runs inference on every cell of a fixed
+grid (uniform budget across the frame). Here inference budget goes where
+the application points it — a coarse always-on safety net via the static
+tile, plus a high-detail tracker tile via the dynamic injection.
 
 Works on x86_64 and aarch64 (RPi). The plugin .so is preloaded via
 ``pkg-config --variable=pluginsdir gstreamer-1.0`` so the demo doesn't
@@ -155,9 +184,35 @@ def DYNAMIC_TILE_CROPPER_PIPELINE(
 
 CROPPER_NAME = "dyn_tc"
 
+# Static tile: a *large* always-on rectangle on the left half of the frame.
+# Covers a wide area, so when internal-offset rescales it to the model's
+# expected input (e.g. 640x480), each person inside occupies only a small
+# fraction of the tile pixels — detector confidence drops accordingly.
+# Format: "x,y,w,h;…" (normalized 0..1). Use --static-tiles "" to disable.
+DEFAULT_STATIC_TILES = "0.0,0.05,0.5,0.9"
+
 
 class GStreamerDynamicTilingApp(GStreamerTilingApp):
     """Tiling app that uses the community dynamic cropper instead of a fixed grid."""
+
+    def __init__(self, app_callback, user_data, parser=None):
+        # The parent already adds many args via _add_tiling_arguments; we
+        # tack one more on for the static-tile contrast experiment.
+        if parser is None:
+            from hailo_apps.python.core.common.core import get_pipeline_parser
+            parser = get_pipeline_parser()
+        parser.add_argument(
+            "--static-tiles",
+            default=DEFAULT_STATIC_TILES,
+            help=(
+                "Semicolon-separated 'x,y,w,h' rectangles (normalized 0..1) "
+                "passed to hailotilecropper_dynamic's tiles-static property. "
+                f"Default: '{DEFAULT_STATIC_TILES}' (a large always-on tile "
+                "on the left half — lower per-object detail, lower accuracy). "
+                "Pass '' to disable so only the moving dynamic tile runs."
+            ),
+        )
+        super().__init__(app_callback, user_data, parser)
 
     def get_pipeline_string(self) -> str:
         source_pipeline = self.get_source_pipeline()
@@ -175,6 +230,7 @@ class GStreamerDynamicTilingApp(GStreamerTilingApp):
             name=CROPPER_NAME,
             internal_offset=True,
             iou_threshold=self.iou_threshold,
+            tiles_static=self.options_menu.static_tiles,
         )
 
         user_callback_pipeline = USER_CALLBACK_PIPELINE()
@@ -198,13 +254,22 @@ class GStreamerDynamicTilingApp(GStreamerTilingApp):
 # ---------------------------------------------------------------------------
 
 class TileWalker:
-    """Returns a moving 0.4-wide tile each frame; left edge bounces in [0.1, 0.5]."""
+    """Returns a small moving tile each frame; left edge bounces across the frame.
 
-    TILE_W = 0.4
-    TILE_H = 0.4
-    TILE_Y = 0.2
-    X_MIN = 0.1
-    X_MAX = 0.5
+    Intentionally smaller than the default static tile so that, when an object
+    falls inside the dynamic crop, internal-offset's rescale-to-model-input
+    upscales fewer source pixels by a larger factor — the object occupies a
+    larger fraction of the model's input field, and per-object confidence
+    typically rises versus what the static tile alone produces.
+    """
+
+    TILE_W = 0.2
+    TILE_H = 0.3
+    TILE_Y = 0.25
+    # Walk the left edge across most of the frame; X_MAX is set so the tile
+    # stays in-frame (X_MAX + TILE_W ≤ 1.0).
+    X_MIN = 0.0
+    X_MAX = 0.8
     PHASE_STEP = 0.02
 
     def __init__(self):

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
@@ -212,7 +212,36 @@ class GStreamerDynamicTilingApp(GStreamerTilingApp):
                 "Pass '' to disable so only the moving dynamic tile runs."
             ),
         )
+        # Walker survives EOS rebuilds so the tile keeps moving smoothly when
+        # the framework reloads the file. We attach the handoff after each
+        # rebuild via _on_pipeline_rebuilt below.
+        self._walker = TileWalker()
         super().__init__(app_callback, user_data, parser)
+        self._connect_tile_handoff()
+
+    def _connect_tile_handoff(self):
+        """Bind the per-frame tile-injection handoff to the (possibly fresh)
+        ``{CROPPER_NAME}_tile_setter`` element in the current pipeline.
+
+        Called once from __init__ and again from ``_on_pipeline_rebuilt``
+        after the framework recreates the pipeline on EOS.
+        """
+        tile_setter = self.pipeline.get_by_name(f"{CROPPER_NAME}_tile_setter")
+        if tile_setter is None:
+            raise RuntimeError(
+                f"could not find '{CROPPER_NAME}_tile_setter' in the pipeline — "
+                "DYNAMIC_TILE_CROPPER_PIPELINE wiring is wrong"
+            )
+        tile_setter.connect("handoff", make_tile_handoff(self._walker))
+
+    def _on_pipeline_rebuilt(self):
+        """Reattach the dynamic-tile handoff after the framework rebuilds the
+        pipeline on EOS. Without this, the new ``tile_setter`` identity has
+        no signal handler and the dynamic tile vanishes from the second loop
+        onward (only the static tile keeps producing crops).
+        """
+        super()._on_pipeline_rebuilt()
+        self._connect_tile_handoff()
 
     def get_pipeline_string(self) -> str:
         source_pipeline = self.get_source_pipeline()
@@ -323,18 +352,8 @@ def main() -> None:
 
     user_data = UserData()
     app = GStreamerDynamicTilingApp(app_callback, user_data)
-
-    # Wire dynamic-tile injection. Must happen after the pipeline has been
-    # built (in the parent's __init__) and before app.run() flips state.
-    walker = TileWalker()
-    tile_setter = app.pipeline.get_by_name(f"{CROPPER_NAME}_tile_setter")
-    if tile_setter is None:
-        raise RuntimeError(
-            f"could not find '{CROPPER_NAME}_tile_setter' in the pipeline — "
-            "DYNAMIC_TILE_CROPPER_PIPELINE wiring is wrong"
-        )
-    tile_setter.connect("handoff", make_tile_handoff(walker))
-
+    # Tile handoff is wired in the constructor and re-wired on every EOS
+    # rebuild via _on_pipeline_rebuilt — nothing more to do here.
     app.run()
 
 

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/examples/tiling_dynamic_demo.py
@@ -1,0 +1,153 @@
+"""Demo: hailotilecropper_dynamic with a moving dynamic tile.
+
+Demonstrates:
+  - src_0 (bypass): full original frame flows through to the aggregator main input
+  - src_1 (crop):   one tile per frame around a moving region (dynamic)
+  - The tile bbox walks left-to-right and back across the frame
+
+In a real pipeline you would replace the ``identity name=fake_inf`` element
+with a ``hailofilter`` running inference on the cropped tile.  The aggregator
+(``hailotileaggregator``) then merges the per-tile detections back into the
+full-frame coordinate space.
+
+Note on display: ``hailotileaggregator`` does not expose caps on its src pad
+in a way that ``videoconvert`` / ``autovideosink`` can negotiate.  The demo
+therefore uses ``fakesink`` for headless validation.  In production, wire the
+aggregator's src pad into a ``hailodisplay`` or a ``hailooverlay ! videoconvert
+! autovideosink`` chain that pulls caps from upstream elements.
+
+Press Ctrl-C to stop.
+
+The demo prefers the freshly built .so under build.release/ when present (so it
+runs before ``sudo hailo-compile-postprocess install`` updates the system .so).
+
+Usage::
+
+    python examples/tiling_dynamic_demo.py
+    python examples/tiling_dynamic_demo.py --frames 300
+    python examples/tiling_dynamic_demo.py --width 320 --height 240
+"""
+import argparse
+import ctypes
+import pathlib
+import sys
+
+# ---------------------------------------------------------------------------
+# Preload the freshest plugin .so before GStreamer init — same approach as
+# tests/e2e/conftest.py.  Needed when the system-installed .so is stale.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]  # …/hailo-apps-infra
+_BUILD_SO = (
+    _REPO_ROOT / "hailo_apps" / "postprocess" / "build.release" / "cpp"
+    / "libgsthailotilecropper_dynamic.so"
+)
+_SYS_SO = pathlib.Path(
+    "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthailotilecropper_dynamic.so"
+)
+
+
+def _preferred_so() -> pathlib.Path | None:
+    if _BUILD_SO.exists() and _SYS_SO.exists():
+        return _BUILD_SO if _BUILD_SO.stat().st_mtime > _SYS_SO.stat().st_mtime else _SYS_SO
+    return _BUILD_SO if _BUILD_SO.exists() else (_SYS_SO if _SYS_SO.exists() else None)
+
+
+_so = _preferred_so()
+if _so is not None:
+    print(f"Preloading: {_so}", flush=True)
+    ctypes.CDLL(str(_so), mode=ctypes.RTLD_GLOBAL)
+
+import gi  # noqa: E402
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst, GLib  # noqa: E402
+import hailo  # noqa: E402
+
+Gst.init(None)
+
+# ---------------------------------------------------------------------------
+# Dynamic tile callback
+# ---------------------------------------------------------------------------
+
+def make_attach_dynamic_tile():
+    """Return a handoff callback that attaches a single dynamic tile per buffer.
+
+    Walks the tile bbox left-to-right and back across the frame.  In a real
+    app this is where you'd plug in tracker output.
+    """
+    state = {"phase": 0.0, "frames": 0}
+
+    def handoff(_identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        # x oscillates between 0.1 and 0.5 so the 0.4-wide tile stays in frame
+        x = 0.1 + 0.4 * abs((state["phase"] % 2.0) - 1.0)
+        roi.add_object(hailo.HailoTileROI(
+            hailo.HailoBBox(x, 0.2, 0.4, 0.4),
+            0, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
+        ))
+        state["phase"] += 0.05
+        state["frames"] += 1
+        if state["frames"] % 30 == 0:
+            print(f"  frame {state['frames']:5d}  tile x={x:.3f}", flush=True)
+
+    return handoff
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--width", type=int, default=640)
+    p.add_argument("--height", type=int, default=480)
+    p.add_argument("--frames", type=int, default=0,
+                   help="Number of frames to process (0 = run until Ctrl-C)")
+    args = p.parse_args()
+
+    num_buffers = f"num-buffers={args.frames}" if args.frames > 0 else ""
+
+    pipeline_str = (
+        f"videotestsrc is-live=false {num_buffers} ! "
+        f"videoconvert ! "
+        f"video/x-raw,format=RGB,width={args.width},height={args.height},framerate=30/1 ! "
+        "identity name=tile_setter signal-handoffs=true ! "
+        "hailotilecropper_dynamic name=tc "
+        "tc.src_0 ! queue ! agg.sink_0 "
+        "tc.src_1 ! queue ! identity name=fake_inf signal-handoffs=true ! agg.sink_1 "
+        "hailotileaggregator name=agg flatten-detections=true iou-threshold=0.3 "
+        "agg.src ! fakesink sync=false async=false"
+    )
+    print(f"Pipeline:\n  {pipeline_str}\n", flush=True)
+
+    pipe = Gst.parse_launch(pipeline_str)
+    pipe.get_by_name("tile_setter").connect("handoff", make_attach_dynamic_tile())
+
+    loop = GLib.MainLoop()
+    bus = pipe.get_bus()
+    bus.add_signal_watch()
+
+    def on_msg(_b, msg):
+        t = msg.type
+        if t == Gst.MessageType.EOS:
+            print("EOS received — stopping.", flush=True)
+            loop.quit()
+        elif t == Gst.MessageType.ERROR:
+            err, dbg = msg.parse_error()
+            print(f"ERROR: {err.message}\n{dbg}", file=sys.stderr)
+            loop.quit()
+    bus.connect("message", on_msg)
+
+    pipe.set_state(Gst.State.PLAYING)
+    print("Pipeline running — press Ctrl-C to stop.\n", flush=True)
+    try:
+        loop.run()
+    except KeyboardInterrupt:
+        print("\nInterrupted.", flush=True)
+    finally:
+        pipe.set_state(Gst.State.NULL)
+    print("Pipeline stopped.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
@@ -24,8 +24,8 @@
 #include "gsthailodspbufferpoolutils.hpp"
 #endif
 
-GST_DEBUG_CATEGORY_STATIC(gst_hailo_basecropper_debug);
-#define GST_CAT_DEFAULT gst_hailo_basecropper_debug
+GST_DEBUG_CATEGORY_STATIC(gst_hailo_basecropper_dyn_debug);
+#define GST_CAT_DEFAULT gst_hailo_basecropper_dyn_debug
 
 enum
 {
@@ -43,52 +43,52 @@ enum
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE("sink",
                                                                    GST_PAD_SINK,
                                                                    GST_PAD_ALWAYS,
-                                                                   GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+                                                                   GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS_DYN));
 
 // We define two source pad templates, one for the main stream and one for the cropped stream.
 // Altough they are the same, we need to define them separately to support a proper caps negotiation in some platforms.
 static GstStaticPadTemplate main_src_factory = GST_STATIC_PAD_TEMPLATE("src_0",
                                                                        GST_PAD_SRC,
                                                                        GST_PAD_ALWAYS,
-                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS_DYN));
 
 static GstStaticPadTemplate crop_src_factory = GST_STATIC_PAD_TEMPLATE("src_1",
                                                                        GST_PAD_SRC,
                                                                        GST_PAD_ALWAYS,
-                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS_DYN));
 #define _debug_init \
-    GST_DEBUG_CATEGORY_INIT(gst_hailo_basecropper_debug, "hailobasecropper", 0, "hailobasecropper element");
-#define gst_hailo_basecropper_parent_class parent_class
-G_DEFINE_ABSTRACT_TYPE_WITH_CODE(GstHailoBaseCropper, gst_hailo_basecropper, GST_TYPE_ELEMENT, _debug_init);
+    GST_DEBUG_CATEGORY_INIT(gst_hailo_basecropper_dyn_debug, "hailobasecropper", 0, "hailobasecropper element");
+#define gst_hailo_basecropper_dyn_parent_class parent_class
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE(GstHailoBaseCropperDyn, gst_hailo_basecropper_dyn, GST_TYPE_ELEMENT, _debug_init);
 
-static void gst_hailo_basecropper_set_property(GObject *object,
+static void gst_hailo_basecropper_dyn_set_property(GObject *object,
                                                guint prop_id, const GValue *value, GParamSpec *pspec);
-static void gst_hailo_basecropper_get_property(GObject *object,
+static void gst_hailo_basecropper_dyn_get_property(GObject *object,
                                                guint prop_id, GValue *value, GParamSpec *pspec);
 
-static gboolean gst_hailo_basecropper_sink_event(GstPad *pad,
+static gboolean gst_hailo_basecropper_dyn_sink_event(GstPad *pad,
                                                  GstObject *parent, GstEvent *event);
-static gboolean gst_hailo_basecropper_sink_query(GstPad *pad,
+static gboolean gst_hailo_basecropper_dyn_sink_query(GstPad *pad,
                                                  GstObject *parent, GstQuery *query);
-static gboolean gst_hailo_basecropper_src_query(GstPad *pad,
+static gboolean gst_hailo_basecropper_dyn_src_query(GstPad *pad,
                                                 GstObject *parent, GstQuery *query);
-static GstFlowReturn gst_hailo_basecropper_chain(GstPad *pad,
+static GstFlowReturn gst_hailo_basecropper_dyn_chain(GstPad *pad,
                                                  GstObject *parent, GstBuffer *buf);
 
-static void gst_hailo_basecropper_dispose(GObject *object);
+static void gst_hailo_basecropper_dyn_dispose(GObject *object);
 
-static gboolean gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, GstQuery *query);
+static gboolean gst_hailo_basecropper_dyn_decide_allocation(GstHailoBaseCropperDyn *hailo_basecropper, GstQuery *query);
 
-static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size);
+static GstBuffer *gst_hailo_basecropper_dyn_allocate_new_buffer(GstHailoBaseCropperDyn *hailo_basecropper, size_t buffer_size);
 
 #ifdef HAILO15_TARGET
-static gboolean dsp_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
+static gboolean dsp_crop_and_resize(GstHailoBaseCropperDyn *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
                                     GstBuffer *input_buffer, GstVideoInfo *input_video_info, GstBuffer *output_buffer, GstVideoInfo *output_video_info);
-static gboolean gst_hailo_basecropper_propose_allocation(GstHailoBaseCropper *hailo_basecropper, GstPad *pad, GstQuery *query);
+static gboolean gst_hailo_basecropper_dyn_propose_allocation(GstHailoBaseCropperDyn *hailo_basecropper, GstPad *pad, GstQuery *query);
 #endif
 
 static void
-gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
+gst_hailo_basecropper_dyn_class_init(GstHailoBaseCropperDynClass *klass)
 {
     GObjectClass *gobject_class;
     GstElementClass *gstelement_class;
@@ -96,9 +96,9 @@ gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
     gobject_class = (GObjectClass *)klass;
     gstelement_class = (GstElementClass *)klass;
 
-    gobject_class->set_property = gst_hailo_basecropper_set_property;
-    gobject_class->get_property = gst_hailo_basecropper_get_property;
-    gobject_class->dispose = GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dispose);
+    gobject_class->set_property = gst_hailo_basecropper_dyn_set_property;
+    gobject_class->get_property = gst_hailo_basecropper_dyn_get_property;
+    gobject_class->dispose = GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dyn_dispose);
 
     g_object_class_install_property(gobject_class, PROP_USE_INTERNAL_OFFSET,
                                     g_param_spec_boolean("internal-offset", "Internal Offset",
@@ -145,12 +145,12 @@ gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
 }
 
 static void
-gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
+gst_hailo_basecropper_dyn_init(GstHailoBaseCropperDyn *hailo_basecropper)
 {
     hailo_basecropper->sinkpad = gst_pad_new_from_static_template(&sink_factory, "sink");
-    gst_pad_set_event_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_sink_event));
-    gst_pad_set_chain_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_chain));
-    gst_pad_set_query_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_sink_query));
+    gst_pad_set_event_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dyn_sink_event));
+    gst_pad_set_chain_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dyn_chain));
+    gst_pad_set_query_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dyn_sink_query));
     GST_PAD_SET_PROXY_CAPS(hailo_basecropper->sinkpad);
     gst_element_add_pad(GST_ELEMENT(hailo_basecropper), hailo_basecropper->sinkpad);
 
@@ -161,7 +161,7 @@ gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
     hailo_basecropper->srcpad_crop = gst_pad_new_from_static_template(&crop_src_factory, "src_1");
     GST_PAD_SET_PROXY_CAPS(hailo_basecropper->srcpad_crop);
     gst_element_add_pad(GST_ELEMENT(hailo_basecropper), hailo_basecropper->srcpad_crop);
-    gst_pad_set_query_function(hailo_basecropper->srcpad_crop, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_src_query));
+    gst_pad_set_query_function(hailo_basecropper->srcpad_crop, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dyn_src_query));
 
 // Set default values.
 #ifdef HAILO15_TARGET
@@ -182,7 +182,7 @@ gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
 
 #ifdef HAILO15_TARGET
 static gboolean
-gst_hailo_basecropper_propose_allocation(GstHailoBaseCropper *hailo_basecropper, GstPad *pad, GstQuery *query)
+gst_hailo_basecropper_dyn_propose_allocation(GstHailoBaseCropperDyn *hailo_basecropper, GstPad *pad, GstQuery *query)
 {
     gboolean ret = gst_pad_peer_query(hailo_basecropper->srcpad_main, query);
     if (!ret)
@@ -193,9 +193,9 @@ gst_hailo_basecropper_propose_allocation(GstHailoBaseCropper *hailo_basecropper,
 }
 #endif
 
-static void gst_hailo_basecropper_dispose(GObject *object)
+static void gst_hailo_basecropper_dyn_dispose(GObject *object)
 {
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN(object);
     GST_INFO_OBJECT(hailo_basecropper, "Performing Dispose");
 
     if (hailo_basecropper->buffer_pool)
@@ -205,11 +205,11 @@ static void gst_hailo_basecropper_dispose(GObject *object)
         hailo_basecropper->buffer_pool = NULL;
     }
 
-    G_OBJECT_CLASS(gst_hailo_basecropper_parent_class)->dispose(object);
+    G_OBJECT_CLASS(gst_hailo_basecropper_dyn_parent_class)->dispose(object);
 }
 
 static gboolean
-gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, GstQuery *query)
+gst_hailo_basecropper_dyn_decide_allocation(GstHailoBaseCropperDyn *hailo_basecropper, GstQuery *query)
 {
     gboolean ret = TRUE;
 
@@ -234,7 +234,7 @@ gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, 
 }
 
 static void
-set_filter_streams(GstHailoBaseCropper *hailo_basecropper, const GValue *value)
+set_filter_streams(GstHailoBaseCropperDyn *hailo_basecropper, const GValue *value)
 {
     // Insert the elements of Gvalue represents filter streams into the char array 'filter_streams'
     if (value == NULL)
@@ -259,7 +259,7 @@ set_filter_streams(GstHailoBaseCropper *hailo_basecropper, const GValue *value)
     return;
 }
 static void
-get_filter_streams(GstHailoBaseCropper *hailo_basecropper, GValue *value)
+get_filter_streams(GstHailoBaseCropperDyn *hailo_basecropper, GValue *value)
 {
     // Insert the elements of Gvalue represents input streams into the char array 'input_streams'
     if (value == NULL)
@@ -283,10 +283,10 @@ get_filter_streams(GstHailoBaseCropper *hailo_basecropper, GValue *value)
 }
 
 static void
-gst_hailo_basecropper_set_property(GObject *object, guint prop_id,
+gst_hailo_basecropper_dyn_set_property(GObject *object, guint prop_id,
                                    const GValue *value, GParamSpec *pspec)
 {
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN(object);
 
     switch (prop_id)
     {
@@ -317,10 +317,10 @@ gst_hailo_basecropper_set_property(GObject *object, guint prop_id,
 }
 
 static void
-gst_hailo_basecropper_get_property(GObject *object, guint prop_id,
+gst_hailo_basecropper_dyn_get_property(GObject *object, guint prop_id,
                                    GValue *value, GParamSpec *pspec)
 {
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN(object);
 
     switch (prop_id)
     {
@@ -361,7 +361,7 @@ gst_hailo_basecropper_get_property(GObject *object, guint prop_id,
  * @return Upon success, returns true. Otherwise, returns false.
  */
 static gboolean
-gst_crop_scale_setcaps(GstHailoBaseCropper *hailo_basecropper, GstCaps *fallback_caps)
+gst_crop_scale_setcaps(GstHailoBaseCropperDyn *hailo_basecropper, GstCaps *fallback_caps)
 {
     GstCaps *caps_result, *outcaps = NULL;
     GstQuery *query = NULL;
@@ -424,7 +424,7 @@ gst_hailo_handle_caps_query(GstPad *pad, GstQuery *query)
 }
 
 static gboolean
-gst_hailo_basecropper_src_query(GstPad *pad,
+gst_hailo_basecropper_dyn_src_query(GstPad *pad,
                                 GstObject *parent, GstQuery *query)
 {
     gboolean ret;
@@ -447,11 +447,11 @@ gst_hailo_basecropper_src_query(GstPad *pad,
 }
 
 static gboolean
-gst_hailo_basecropper_sink_query(GstPad *pad,
+gst_hailo_basecropper_dyn_sink_query(GstPad *pad,
                                  GstObject *parent, GstQuery *query)
 {
     gboolean ret;
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(parent);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN(parent);
 
     switch (GST_QUERY_TYPE(query))
     {
@@ -464,7 +464,7 @@ gst_hailo_basecropper_sink_query(GstPad *pad,
     {
         GST_DEBUG_OBJECT(hailo_basecropper, "Received allocation query from sinkpad in hailo_basecropper");
 #ifdef HAILO15_TARGET
-        ret = gst_hailo_basecropper_propose_allocation(hailo_basecropper, pad, query);
+        ret = gst_hailo_basecropper_dyn_propose_allocation(hailo_basecropper, pad, query);
         if (!ret)
             GST_DEBUG_OBJECT(hailo_basecropper, "Failed to query peer srcpad_main");
 #else
@@ -491,10 +491,10 @@ gst_hailo_basecropper_sink_query(GstPad *pad,
 }
 
 static gboolean
-gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
+gst_hailo_basecropper_dyn_sink_event(GstPad *pad, GstObject *parent,
                                  GstEvent *event)
 {
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(parent);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN(parent);
     gboolean ret;
 
     GST_LOG_OBJECT(hailo_basecropper, "Received %s event: %" GST_PTR_FORMAT,
@@ -537,7 +537,7 @@ gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
         }
 
         // Peer srcpad_crop has replied, perform decide allocation
-        gst_hailo_basecropper_decide_allocation(hailo_basecropper, crop_query);
+        gst_hailo_basecropper_dyn_decide_allocation(hailo_basecropper, crop_query);
 
         gst_query_unref(crop_query);
         break;
@@ -569,7 +569,7 @@ gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
 }
 
 #ifdef HAILO15_TARGET
-dsp_interpolation_type_t get_dsp_interpolation_type_from_cv(GstHailoBaseCropper *hailo_basecropper, cv::InterpolationFlags interpolation)
+dsp_interpolation_type_t get_dsp_interpolation_type_from_cv(GstHailoBaseCropperDyn *hailo_basecropper, cv::InterpolationFlags interpolation)
 {
     switch (interpolation)
     {
@@ -589,7 +589,7 @@ dsp_interpolation_type_t get_dsp_interpolation_type_from_cv(GstHailoBaseCropper 
 }
 #endif
 
-static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size)
+static GstBuffer *gst_hailo_basecropper_dyn_allocate_new_buffer(GstHailoBaseCropperDyn *hailo_basecropper, size_t buffer_size)
 {
     GstBuffer *output_buffer = NULL;
 
@@ -621,7 +621,7 @@ static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper 
 }
 
 #ifdef HAILO15_TARGET
-static gboolean dsp_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
+static gboolean dsp_crop_and_resize(GstHailoBaseCropperDyn *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
                                     GstBuffer *input_buffer, GstVideoInfo *input_video_info, GstBuffer *output_buffer, GstVideoInfo *output_video_info)
 {
     dsp_utils::crop_resize_dims_t crop_resize_dims = {
@@ -704,9 +704,9 @@ static gboolean dsp_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, cv::
 }
 #endif
 
-static gboolean opencv_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, std::shared_ptr<HailoMat> resized_image, std::shared_ptr<HailoMat> full_image, GstVideoInfo *full_image_info, HailoROIPtr crop_roi)
+static gboolean opencv_crop_and_resize(GstHailoBaseCropperDyn *hailo_basecropper, std::shared_ptr<HailoMat> resized_image, std::shared_ptr<HailoMat> full_image, GstVideoInfo *full_image_info, HailoROIPtr crop_roi)
 {
-    GstHailoBaseCropperClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_GET_CLASS(hailo_basecropper);
+    GstHailoBaseCropperDynClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_DYN_GET_CLASS(hailo_basecropper);
     std::vector<cv::Mat> resized_cv_mat = resized_image->get_matrices();
 
     GST_DEBUG_OBJECT(hailo_basecropper, "Opencv Crop + Resize: Input Width: %d, Height: %d. \
@@ -736,7 +736,7 @@ static gboolean opencv_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, s
  * @param[in] crop_roi          Reference to a ROI Object to crop dimensions.
  * @return A new buffer, cropped and scaled for a second network.
  */
-static GstBuffer *handle_one_crop(GstHailoBaseCropper *hailo_basecropper, GstBuffer *input_buffer, HailoROIPtr crop_roi)
+static GstBuffer *handle_one_crop(GstHailoBaseCropperDyn *hailo_basecropper, GstBuffer *input_buffer, HailoROIPtr crop_roi)
 {
     GstCaps *incaps, *outcaps;
     GstBuffer *output_buffer = NULL;
@@ -800,7 +800,7 @@ static GstBuffer *handle_one_crop(GstHailoBaseCropper *hailo_basecropper, GstBuf
     size_t buffer_size = get_size(outcaps);
     GST_DEBUG_OBJECT(hailo_basecropper, "Allocating output buffer size: %d", (int)buffer_size);
     // Allocate new GstBuffer
-    output_buffer = gst_hailo_basecropper_allocate_new_buffer(hailo_basecropper, buffer_size);
+    output_buffer = gst_hailo_basecropper_dyn_allocate_new_buffer(hailo_basecropper, buffer_size);
 
     // Get cv matrix of full image from buffer
     std::shared_ptr<HailoMat> full_image = get_mat_by_format(input_buffer, full_image_info);
@@ -845,7 +845,7 @@ static GstBuffer *handle_one_crop(GstHailoBaseCropper *hailo_basecropper, GstBuf
  * @param[in] crop_rois        Vector of HailoROI of buf to crop from.
  * @return boolean, whether all cropping were successful.
  */
-static gboolean handle_crops(GstHailoBaseCropper *hailo_basecropper, GstBuffer *buf, std::vector<HailoROIPtr> &crop_rois)
+static gboolean handle_crops(GstHailoBaseCropperDyn *hailo_basecropper, GstBuffer *buf, std::vector<HailoROIPtr> &crop_rois)
 {
     for (HailoROIPtr &crop_roi : crop_rois)
     {
@@ -868,7 +868,7 @@ static gboolean handle_crops(GstHailoBaseCropper *hailo_basecropper, GstBuffer *
     return TRUE;
 }
 
-uint filter_streams_have_name(GstHailoBaseCropper *hailo_basecropper, const gchar *name)
+uint filter_streams_have_name(GstHailoBaseCropperDyn *hailo_basecropper, const gchar *name)
 {
     for (uint i = 0; i < hailo_basecropper->num_streams_to_filter; ++i)
     {
@@ -878,10 +878,10 @@ uint filter_streams_have_name(GstHailoBaseCropper *hailo_basecropper, const gcha
     return 0;
 }
 
-static GstFlowReturn gst_hailo_basecropper_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
+static GstFlowReturn gst_hailo_basecropper_dyn_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
 {
-    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER_CAST(parent);
-    GstHailoBaseCropperClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_GET_CLASS(hailo_basecropper);
+    GstHailoBaseCropperDyn *hailo_basecropper = GST_HAILO_BASE_CROPPER_DYN_CAST(parent);
+    GstHailoBaseCropperDynClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_DYN_GET_CLASS(hailo_basecropper);
     buf = gst_buffer_make_writable(buf);
 
     // Prepare crops and flags

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
@@ -1,0 +1,805 @@
+/**
+ * Copyright (c) 2021-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the LGPL license (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+ **/
+#include <gst/gst.h>
+#include <gst/video/video.h>
+#include <iomanip>
+#include <iostream>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <map>
+#include <typeinfo>
+#include "common/image.hpp"
+#include "hailomat_internal.hpp"
+#include "cropping/gsthailobasecropper.hpp"
+#include "gst_hailo_cropping_meta.hpp"
+#include "gst_hailo_stream_meta.hpp"
+#include "hailo_objects.hpp"
+#include "hailo_common.hpp"
+#include "gst_hailo_meta.hpp"
+
+GST_DEBUG_CATEGORY_STATIC(gst_hailo_basecropper_debug);
+#define GST_CAT_DEFAULT gst_hailo_basecropper_debug
+
+enum
+{
+    PROP_0,
+    PROP_USE_INTERNAL_OFFSET,
+    PROP_DROP_UNCROPPED_BUFFERS,
+    PROP_CROPPING_PERIOD,
+    PROP_FILTER_STREAMS,
+};
+
+static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE("sink",
+                                                                   GST_PAD_SINK,
+                                                                   GST_PAD_ALWAYS,
+                                                                   GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+
+// We define two source pad templates, one for the main stream and one for the cropped stream.
+// Altough they are the same, we need to define them separately to support a proper caps negotiation in some platforms.
+static GstStaticPadTemplate main_src_factory = GST_STATIC_PAD_TEMPLATE("src_0",
+                                                                       GST_PAD_SRC,
+                                                                       GST_PAD_ALWAYS,
+                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+
+static GstStaticPadTemplate crop_src_factory = GST_STATIC_PAD_TEMPLATE("src_1",
+                                                                       GST_PAD_SRC,
+                                                                       GST_PAD_ALWAYS,
+                                                                       GST_STATIC_CAPS(HAILO_BASE_CROPPER_VIDEO_CAPS));
+#define _debug_init \
+    GST_DEBUG_CATEGORY_INIT(gst_hailo_basecropper_debug, "hailobasecropper", 0, "hailobasecropper element");
+#define gst_hailo_basecropper_parent_class parent_class
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE(GstHailoBaseCropper, gst_hailo_basecropper, GST_TYPE_ELEMENT, _debug_init);
+
+static void gst_hailo_basecropper_set_property(GObject *object,
+                                               guint prop_id, const GValue *value, GParamSpec *pspec);
+static void gst_hailo_basecropper_get_property(GObject *object,
+                                               guint prop_id, GValue *value, GParamSpec *pspec);
+
+static gboolean gst_hailo_basecropper_sink_event(GstPad *pad,
+                                                 GstObject *parent, GstEvent *event);
+static gboolean gst_hailo_basecropper_sink_query(GstPad *pad,
+                                                 GstObject *parent, GstQuery *query);
+static gboolean gst_hailo_basecropper_src_query(GstPad *pad,
+                                                GstObject *parent, GstQuery *query);
+static GstFlowReturn gst_hailo_basecropper_chain(GstPad *pad,
+                                                 GstObject *parent, GstBuffer *buf);
+
+static void gst_hailo_basecropper_dispose(GObject *object);
+
+static gboolean gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, GstQuery *query);
+
+static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size);
+
+static void
+gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
+{
+    GObjectClass *gobject_class;
+    GstElementClass *gstelement_class;
+
+    gobject_class = (GObjectClass *)klass;
+    gstelement_class = (GstElementClass *)klass;
+
+    gobject_class->set_property = gst_hailo_basecropper_set_property;
+    gobject_class->get_property = gst_hailo_basecropper_get_property;
+    gobject_class->dispose = GST_DEBUG_FUNCPTR(gst_hailo_basecropper_dispose);
+
+    g_object_class_install_property(gobject_class, PROP_USE_INTERNAL_OFFSET,
+                                    g_param_spec_boolean("internal-offset", "Internal Offset",
+                                                         "Whether to use Gstreamer offset of internal offset. \nNOTE: If using file sources, Gstreamer does not generate offsets for buffers, so this property should be set to true in such cases.", false,
+                                                         (GParamFlags)(GST_PARAM_CONTROLLABLE | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+    g_object_class_install_property(gobject_class, PROP_DROP_UNCROPPED_BUFFERS,
+                                    g_param_spec_boolean("drop-uncropped-buffers", "Drop Uncropped Buffers",
+                                                         "If true, then this element will drop buffers that have no croppable ROIs. Default false.", false,
+                                                         (GParamFlags)(GST_PARAM_CONTROLLABLE | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+    g_object_class_install_property(gobject_class, PROP_CROPPING_PERIOD,
+                                    g_param_spec_uint("cropping-period", "Cropping Period",
+                                                      "Period of of how often to crop buffers. Can be thought of as 'cropping every x buffers'. Default 1 (every buffer)",
+                                                      1, G_MAXINT, 1,
+                                                      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
+    g_object_class_install_property(gobject_class, PROP_FILTER_STREAMS,
+                                    gst_param_spec_array("filter-streams", "Filter Streams",
+                                                         "Filter specific streams to crop. Streams are filtered by GstHailoStreamMeta (see hailoroundrobin element). Default behavior crops all streams. \nExample usage: filter-streams=\'<sink_1, sink_3>\'",
+                                                         g_param_spec_string("filter-stream-name", "Filter stream name",
+                                                                             "Filter stream", "",
+                                                                             (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)),
+                                                         (GParamFlags)(G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS)));
+
+    gst_element_class_add_pad_template(gstelement_class,
+                                       gst_static_pad_template_get(&main_src_factory));
+    gst_element_class_add_pad_template(gstelement_class,
+                                       gst_static_pad_template_get(&crop_src_factory));
+    gst_element_class_add_pad_template(gstelement_class,
+                                       gst_static_pad_template_get(&sink_factory));
+
+    klass->prepare_crops = nullptr;
+    klass->resize = nullptr;
+}
+
+static void
+gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
+{
+    hailo_basecropper->sinkpad = gst_pad_new_from_static_template(&sink_factory, "sink");
+    gst_pad_set_event_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_sink_event));
+    gst_pad_set_chain_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_chain));
+    gst_pad_set_query_function(hailo_basecropper->sinkpad, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_sink_query));
+    GST_PAD_SET_PROXY_CAPS(hailo_basecropper->sinkpad);
+    gst_element_add_pad(GST_ELEMENT(hailo_basecropper), hailo_basecropper->sinkpad);
+
+    hailo_basecropper->srcpad_main = gst_pad_new_from_static_template(&main_src_factory, "src_0");
+    GST_PAD_SET_PROXY_CAPS(hailo_basecropper->srcpad_main);
+    gst_element_add_pad(GST_ELEMENT(hailo_basecropper), hailo_basecropper->srcpad_main);
+
+    hailo_basecropper->srcpad_crop = gst_pad_new_from_static_template(&crop_src_factory, "src_1");
+    GST_PAD_SET_PROXY_CAPS(hailo_basecropper->srcpad_crop);
+    gst_element_add_pad(GST_ELEMENT(hailo_basecropper), hailo_basecropper->srcpad_crop);
+    gst_pad_set_query_function(hailo_basecropper->srcpad_crop, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_src_query));
+
+// Set default values.
+    hailo_basecropper->use_internal_offset = false;
+    hailo_basecropper->internal_offset = 0;
+    hailo_basecropper->cropping_period = 1;
+    hailo_basecropper->num_streams_to_filter = 0;
+    hailo_basecropper->drop_uncropped_buffers = false;
+    hailo_basecropper->buffer_pool = NULL;
+    hailo_basecropper->stream_ids_buff_offset.clear();
+    for (uint i = 0; i < GST_HAILO_CROPPER_MAX_FILTER_STREAMS; i++)
+        hailo_basecropper->filter_streams[i] = "";
+}
+
+static void gst_hailo_basecropper_dispose(GObject *object)
+{
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+    GST_INFO_OBJECT(hailo_basecropper, "Performing Dispose");
+
+    if (hailo_basecropper->buffer_pool)
+    {
+        GST_DEBUG_OBJECT(hailo_basecropper, "Unreffing buffer pool");
+        gst_object_unref(hailo_basecropper->buffer_pool);
+        hailo_basecropper->buffer_pool = NULL;
+    }
+
+    G_OBJECT_CLASS(gst_hailo_basecropper_parent_class)->dispose(object);
+}
+
+static gboolean
+gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, GstQuery *query)
+{
+    gboolean ret = TRUE;
+
+    return ret;
+}
+
+static void
+set_filter_streams(GstHailoBaseCropper *hailo_basecropper, const GValue *value)
+{
+    // Insert the elements of Gvalue represents filter streams into the char array 'filter_streams'
+    if (value == NULL)
+    {
+        GST_ERROR("initialization of element property filter_streams: value is NULL");
+        return;
+    }
+    guint len = gst_value_array_get_size(value);
+    if (len > 0 && len < GST_HAILO_CROPPER_MAX_FILTER_STREAMS)
+    {
+        for (uint i = 0; i < len; i++)
+        {
+            const GValue *val = gst_value_array_get_value(value, i);
+            hailo_basecropper->filter_streams[i] = g_strdup(g_value_get_string(val));
+        }
+        hailo_basecropper->num_streams_to_filter = len;
+    }
+    else
+    {
+        std::cerr << "initialization of element property filter_streams: value is " << len << " and must be between 0 to " << GST_HAILO_CROPPER_MAX_FILTER_STREAMS << std::endl;
+    }
+    return;
+}
+static void
+get_filter_streams(GstHailoBaseCropper *hailo_basecropper, GValue *value)
+{
+    // Insert the elements of Gvalue represents input streams into the char array 'input_streams'
+    if (value == NULL)
+    {
+        GST_ERROR("initialization of element property filter_streams: value is NULL");
+        return;
+    }
+    guint len = gst_value_array_get_size(value);
+    if (len > 0)
+    {
+        GST_ERROR("initialization of element property filter_streams: value an not empty array");
+        return;
+    }
+    for (uint i = 0; i < hailo_basecropper->num_streams_to_filter; i++)
+    {
+        GValue val = G_VALUE_INIT;
+        g_value_init(&val, G_TYPE_STRING);
+        g_value_set_string(&val, hailo_basecropper->filter_streams[i]);
+        gst_value_array_append_and_take_value(value, &val);
+    }
+}
+
+static void
+gst_hailo_basecropper_set_property(GObject *object, guint prop_id,
+                                   const GValue *value, GParamSpec *pspec)
+{
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+
+    switch (prop_id)
+    {
+    case PROP_USE_INTERNAL_OFFSET:
+        hailo_basecropper->use_internal_offset = g_value_get_boolean(value);
+        break;
+    case PROP_DROP_UNCROPPED_BUFFERS:
+        hailo_basecropper->drop_uncropped_buffers = g_value_get_boolean(value);
+        break;
+    case PROP_CROPPING_PERIOD:
+        hailo_basecropper->cropping_period = g_value_get_uint(value);
+        break;
+    case PROP_FILTER_STREAMS:
+        set_filter_streams(hailo_basecropper, value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+static void
+gst_hailo_basecropper_get_property(GObject *object, guint prop_id,
+                                   GValue *value, GParamSpec *pspec)
+{
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(object);
+
+    switch (prop_id)
+    {
+    case PROP_USE_INTERNAL_OFFSET:
+        g_value_set_boolean(value, hailo_basecropper->use_internal_offset);
+        break;
+    case PROP_DROP_UNCROPPED_BUFFERS:
+        g_value_set_boolean(value, hailo_basecropper->drop_uncropped_buffers);
+        break;
+    case PROP_CROPPING_PERIOD:
+        g_value_set_uint(value, hailo_basecropper->cropping_period);
+        break;
+    case PROP_FILTER_STREAMS:
+        get_filter_streams(hailo_basecropper, value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+/**
+ * Retrieves wanted caps from downstream elements and sets them.
+ *
+ * @param[in] hailo_basecropper      Pointer to the element, used to send caps query on the crop pad.
+ * @return Upon success, returns true. Otherwise, returns false.
+ */
+static gboolean
+gst_crop_scale_setcaps(GstHailoBaseCropper *hailo_basecropper)
+{
+    GstCaps *caps_result, *outcaps = NULL;
+    GstQuery *query = NULL;
+
+    // Create new caps Query;
+    query = gst_query_new_caps(GST_CAPS_ANY);
+
+    // Query the peer pad of cropped pad to obtain wanted resolution.
+    gst_pad_peer_query(hailo_basecropper->srcpad_crop, query);
+    gst_query_parse_caps_result(query, &caps_result);
+
+    // Fixate the caps
+    // gst_caps_fixate takes ownership of caps_result, no need to unref it.
+    outcaps = gst_caps_fixate(caps_result);
+
+    // Set The caps, unref all objects and return.
+    gboolean ret = gst_pad_set_caps(hailo_basecropper->srcpad_crop, outcaps);
+    gst_query_unref(query);
+
+    return ret;
+}
+
+static gboolean
+gst_hailo_handle_caps_query(GstPad *pad, GstQuery *query)
+{
+    GstCaps *caps_result, *allowed_caps, *qcaps;
+    /* we should report the supported caps here which are all */
+    allowed_caps = gst_pad_get_pad_template_caps(pad);
+    gst_query_parse_caps(query, &qcaps);
+
+    if (qcaps)
+    {
+        // caps query - intersect template caps (allowed caps) with incomming caps query
+        caps_result = gst_caps_intersect(allowed_caps, qcaps);
+    }
+    else
+    {
+        // no caps query - return template caps
+        caps_result = allowed_caps;
+    }
+
+    // set the caps result
+    gst_query_set_caps_result(query, caps_result);
+    gst_caps_unref(caps_result);
+
+    return TRUE;
+}
+
+static gboolean
+gst_hailo_basecropper_src_query(GstPad *pad,
+                                GstObject *parent, GstQuery *query)
+{
+    gboolean ret;
+
+    switch (GST_QUERY_TYPE(query))
+    {
+    case GST_QUERY_CAPS:
+    {
+        ret = gst_hailo_handle_caps_query(pad, query);
+        break;
+    }
+    default:
+    {
+        /* just call the default handler */
+        ret = gst_pad_query_default(pad, parent, query);
+        break;
+    }
+    }
+    return ret;
+}
+
+static gboolean
+gst_hailo_basecropper_sink_query(GstPad *pad,
+                                 GstObject *parent, GstQuery *query)
+{
+    gboolean ret;
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(parent);
+
+    switch (GST_QUERY_TYPE(query))
+    {
+    case GST_QUERY_CAPS:
+    {
+        ret = gst_hailo_handle_caps_query(pad, query);
+        break;
+    }
+    case GST_QUERY_ALLOCATION:
+    {
+        GST_DEBUG_OBJECT(hailo_basecropper, "Received allocation query from sinkpad in hailo_basecropper");
+        ret = gst_pad_query_default(pad, parent, query);
+        break;
+    }
+    case GST_QUERY_ACCEPT_CAPS:
+    {
+        GstCaps *caps;
+        gst_query_parse_accept_caps(query, &caps);
+        gst_query_set_accept_caps_result(query, true);
+        ret = TRUE;
+        break;
+    }
+    default:
+    {
+        /* just call the default handler */
+        ret = gst_pad_query_default(pad, parent, query);
+        break;
+    }
+    }
+    return ret;
+}
+
+static gboolean
+gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
+                                 GstEvent *event)
+{
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER(parent);
+    gboolean ret;
+
+    GST_LOG_OBJECT(hailo_basecropper, "Received %s event: %" GST_PTR_FORMAT,
+                   GST_EVENT_TYPE_NAME(event), event);
+
+    switch (GST_EVENT_TYPE(event))
+    {
+
+    case GST_EVENT_CAPS:
+    {
+        GstCaps *caps, *crop_caps;
+
+        gst_event_parse_caps(event, &caps);
+
+        ret = gst_pad_set_caps(hailo_basecropper->srcpad_main, caps);
+        if (!ret)
+        {
+            GST_ERROR_OBJECT(hailo_basecropper, "Unable to set caps on main srcpad");
+            return FALSE;
+        }
+
+        ret = gst_crop_scale_setcaps(hailo_basecropper);
+        if (!ret)
+        {
+            GST_ERROR_OBJECT(hailo_basecropper, "Unable to set caps on crop srcpad");
+            return FALSE;
+        }
+
+        // Get caps from the crop pad
+        crop_caps = gst_pad_get_current_caps(hailo_basecropper->srcpad_crop);
+
+        // Create new allocation query with the crop caps
+        GstQuery *crop_query = gst_query_new_allocation(crop_caps, FALSE);
+
+        // Propose allocation to the crop srcpad
+        GST_DEBUG_OBJECT(hailo_basecropper, "Sending allocation query to the crop srcpad");
+        if (!gst_pad_peer_query(hailo_basecropper->srcpad_crop, crop_query))
+        {
+            GST_DEBUG_OBJECT(hailo_basecropper, "Peer crop srcpad allocation query failed");
+        }
+
+        // Peer srcpad_crop has replied, perform decide allocation
+        gst_hailo_basecropper_decide_allocation(hailo_basecropper, crop_query);
+
+        gst_query_unref(crop_query);
+        break;
+    }
+    case GST_EVENT_STREAM_START:
+    {
+        const gchar *stream_id;
+        gst_event_parse_stream_start(event, &stream_id);
+        if (!stream_id)
+        {
+            GST_ERROR_OBJECT(hailo_basecropper, "No stream ID");
+            return FALSE;
+        }
+        else
+        {
+            GST_DEBUG_OBJECT(hailo_basecropper, "hailo cropper cropping stream %s", stream_id);
+            std::string streamid_key(strdup(stream_id));
+            hailo_basecropper->stream_ids_buff_offset[streamid_key] = 0;
+        }
+        ret = gst_pad_event_default(pad, parent, event);
+        break;
+    }
+    default:
+        ret = gst_pad_event_default(pad, parent, event);
+        break;
+    }
+
+    return ret;
+}
+
+static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size)
+{
+    GstBuffer *output_buffer = NULL;
+    output_buffer = gst_buffer_new_allocate(NULL, buffer_size, NULL);
+    return output_buffer;
+}
+
+static gboolean opencv_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, std::shared_ptr<HailoMat> resized_image, std::shared_ptr<HailoMat> full_image, GstVideoInfo *full_image_info, HailoROIPtr crop_roi)
+{
+    GstHailoBaseCropperClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_GET_CLASS(hailo_basecropper);
+    std::vector<cv::Mat>& resized_cv_mat = get_cv_matrices(*resized_image);
+
+    GST_DEBUG_OBJECT(hailo_basecropper, "Opencv Crop + Resize: Input Width: %d, Height: %d. \
+                    Target Crop shape X: %f Y: %f Width: %f Height: %f. \
+                    Resize width %d height %d\n",
+                     full_image->width(), full_image->height(),
+                     crop_roi->get_bbox().xmin(), crop_roi->get_bbox().ymin(),
+                     crop_roi->get_bbox().width(), crop_roi->get_bbox().height(), resized_cv_mat[0].cols, resized_cv_mat[0].rows);
+    std::vector<cv::Mat> cropped_cv_mat = crop_to_cv_matrices(*full_image, crop_roi);
+
+    GstVideoFormat image_format = GST_VIDEO_INFO_FORMAT(full_image_info);
+    hailo_basecropperclass->resize(hailo_basecropper, cropped_cv_mat, resized_cv_mat, crop_roi, image_format);
+
+    for (uint i = 0; i < (uint)cropped_cv_mat.size(); i++)
+    {
+        cropped_cv_mat[i].release();
+        resized_cv_mat[i].release();
+    }
+    return true;
+}
+
+/**
+ * Create a new GstBuffer, crop and resize the frame to match the crop_roi, add the buffer to the metadata.
+ *
+ * @param[in] hailo_basecropper Cropping element.
+ * @param[in] input_buffer      Buffer to crop & resize.
+ * @param[in] crop_roi          Reference to a ROI Object to crop dimensions.
+ * @return A new buffer, cropped and scaled for a second network.
+ */
+static GstBuffer *handle_one_crop(GstHailoBaseCropper *hailo_basecropper, GstBuffer *input_buffer, HailoROIPtr crop_roi)
+{
+    GstCaps *incaps, *outcaps;
+    GstBuffer *output_buffer = NULL;
+
+    incaps = gst_pad_get_current_caps(hailo_basecropper->sinkpad);
+    if (!incaps)
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Failed to get input CAPS from sinkpad");
+        return NULL;
+    }
+
+    outcaps = gst_pad_get_current_caps(hailo_basecropper->srcpad_crop);
+    if (!outcaps)
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Failed to get output CAPS from srcpad (crop)");
+        gst_caps_unref(incaps);
+        return NULL;
+    }
+
+    // Check both caps have the same format:
+    // Get the structure of the caps
+    const GstStructure *in_structure = gst_caps_get_structure(incaps, 0);
+    const GstStructure *out_structure = gst_caps_get_structure(outcaps, 0);
+
+    // Get the format field from the structure
+    const gchar *in_format = gst_structure_get_string(in_structure, "format");
+    const gchar *out_format = gst_structure_get_string(out_structure, "format");
+
+    // Compare the formats
+    if (g_strcmp0(in_format, out_format) != 0) {
+        GST_ERROR_OBJECT(hailo_basecropper, "Input and output caps have different formats");
+        std::cerr << "ERROR: Hailo Cropper Input and output caps have different formats" << std::endl;
+        gst_caps_unref(incaps);
+        gst_caps_unref(outcaps);
+        return NULL;
+    }
+
+    GstVideoInfo *full_image_info = gst_video_info_new();
+    gst_video_info_from_caps(full_image_info, incaps);
+
+    GstVideoInfo *resized_image_info = gst_video_info_new();
+    gst_video_info_from_caps(resized_image_info, outcaps);
+
+    HailoBBox roi_bbox = crop_roi->get_bbox();
+    bool crop_roi_is_whole_buffer = (roi_bbox.width() == 1.0f && roi_bbox.height() == 1.0f && roi_bbox.xmin() == 0.0f && roi_bbox.ymin() == 0.0f);
+    bool input_res_equals_output_res = (full_image_info->width == resized_image_info->width && full_image_info->height == resized_image_info->height);
+
+    // If the crop ROI is the whole buffer and the input and output resolutions are the same, we can just return a copy of the buffer
+    if (crop_roi_is_whole_buffer && input_res_equals_output_res)
+    {
+        GST_DEBUG_OBJECT(hailo_basecropper, "Crop ROI is the whole buffer and input and output resolutions are the same, returning a copy of the buffer");
+        output_buffer = gst_buffer_ref(input_buffer);
+        gst_buffer_add_hailo_meta(output_buffer, crop_roi);
+        gst_video_info_free(full_image_info);
+        gst_video_info_free(resized_image_info);
+        gst_caps_unref(incaps);
+        gst_caps_unref(outcaps);
+        return output_buffer;
+    }
+
+    size_t buffer_size = get_size(outcaps);
+    GST_DEBUG_OBJECT(hailo_basecropper, "Allocating output buffer size: %d", (int)buffer_size);
+    // Allocate new GstBuffer
+    output_buffer = gst_hailo_basecropper_allocate_new_buffer(hailo_basecropper, buffer_size);
+
+    // Get cv matrix of full image from buffer
+    std::shared_ptr<HailoMat> full_image = get_mat_by_format(input_buffer, full_image_info);
+
+    // Get cv matrix of cropped image from buffer
+    std::shared_ptr<HailoMat> resized_image = get_mat_by_format(output_buffer, resized_image_info);
+
+// Crop and resize the frame
+    opencv_crop_and_resize(hailo_basecropper, resized_image, full_image, full_image_info, crop_roi);
+
+    GST_DEBUG_OBJECT(hailo_basecropper, "Crop and resize done, freeing resources and returning buffer");
+
+    gst_video_info_free(full_image_info);
+    gst_video_info_free(resized_image_info);
+
+    // Add the croopped ROI to the buffer
+    gst_buffer_add_hailo_meta(output_buffer, crop_roi);
+
+    gst_caps_unref(incaps);
+    gst_caps_unref(outcaps);
+
+    return output_buffer;
+}
+
+/**
+ * Creates new crop buffers from given HailoROIs
+ *
+ * @param[in] hailo_basecropper      cropping element.
+ * @param[in] buf               Buffer to crop.
+ * @param[in] crop_rois        Vector of HailoROI of buf to crop from.
+ * @return boolean, whether all cropping were successful.
+ */
+static gboolean handle_crops(GstHailoBaseCropper *hailo_basecropper, GstBuffer *buf, std::vector<HailoROIPtr> &crop_rois)
+{
+    for (HailoROIPtr &crop_roi : crop_rois)
+    {
+        if (!gst_pad_is_active(hailo_basecropper->srcpad_crop))
+        {
+            GST_INFO_OBJECT(hailo_basecropper, "Crop src pad is not active, dropping buffer");
+            return TRUE;
+        }
+        GstBuffer *newbuf = handle_one_crop(hailo_basecropper, buf, crop_roi);
+        if (!newbuf)
+        {
+            GST_WARNING_OBJECT(hailo_basecropper, "Could not crop buffer with offset %jd", buf->offset);
+            return FALSE;
+        }
+        newbuf->offset = buf->offset;
+
+        // Push the cropped buffer into the crop src pad.
+        gst_pad_push(hailo_basecropper->srcpad_crop, newbuf);
+    }
+    return TRUE;
+}
+
+uint filter_streams_have_name(GstHailoBaseCropper *hailo_basecropper, const gchar *name)
+{
+    for (uint i = 0; i < hailo_basecropper->num_streams_to_filter; ++i)
+    {
+        if (strcmp(name, hailo_basecropper->filter_streams[i]) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static GstFlowReturn gst_hailo_basecropper_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
+{
+    GstHailoBaseCropper *hailo_basecropper = GST_HAILO_BASE_CROPPER_CAST(parent);
+    GstHailoBaseCropperClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_GET_CLASS(hailo_basecropper);
+    buf = gst_buffer_make_writable(buf);
+
+    // Prepare crops and flags
+    gchar *stream_id = gst_pad_get_stream_id(pad);
+    std::string streamid_key(stream_id);
+    std::vector<HailoROIPtr> crop_rois;
+    bool stream_requested = true;
+    bool cropping_period_reached = true;
+    gchar *input_stream_name = g_strdup("");
+
+    // Get the input stream name from the stream metadata on the buffer
+    GstHailoStreamMeta *input_stream_meta = gst_buffer_get_hailo_stream_meta(buf);
+    if (input_stream_meta)
+        input_stream_name = input_stream_meta->pad_name;
+
+    // Check if this stream was requested (default support all streams)
+    if (hailo_basecropper->num_streams_to_filter != 0 && !filter_streams_have_name(hailo_basecropper, input_stream_name))
+        stream_requested = false;
+
+    // Check if the requested cyle period is reached (default cycle is every buffer)
+    if ((hailo_basecropper->stream_ids_buff_offset[streamid_key] % hailo_basecropper->cropping_period) != 0)
+        cropping_period_reached = false;
+
+    // If both flags are true then we can crop this frame
+    if (stream_requested && cropping_period_reached)
+        crop_rois = hailo_basecropperclass->prepare_crops(hailo_basecropper, buf);
+
+    GST_DEBUG_OBJECT(hailo_basecropper, "received buffer %p", buf);
+
+    // If there is nothing to crop and dropping is enabled then drop now
+    if (hailo_basecropper->drop_uncropped_buffers && crop_rois.size() == 0)
+    {
+        g_free(stream_id);
+        gst_buffer_unref(buf);
+        return GST_FLOW_OK;
+    }
+
+    if (hailo_basecropper->use_internal_offset)
+    {
+        buf->offset = hailo_basecropper->internal_offset;
+        hailo_basecropper->internal_offset++;
+    }
+    hailo_basecropper->stream_ids_buff_offset[streamid_key]++;
+
+    gst_buffer_add_hailo_cropping_meta(buf, crop_rois.size());
+
+    // Push the main buffer into the main src pad.
+    if (crop_rois.empty())
+    {
+        gst_pad_push(hailo_basecropper->srcpad_main, buf);
+    }
+    else
+    {
+        gst_pad_push(hailo_basecropper->srcpad_main, gst_buffer_ref(buf));
+        gboolean handle_crops_ret = handle_crops(hailo_basecropper, buf, crop_rois);
+        gst_buffer_unref(buf);
+        if (!handle_crops_ret)
+        {
+            g_free(stream_id);
+            return GST_FLOW_ERROR;
+        }
+    }
+    g_free(stream_id);
+    return GST_FLOW_OK;
+}
+
+/**
+ * @brief Resize the an image without aspect preservation.
+ *        Supports RGB/BGR, NV12, and YUY2
+ *
+ * @param method - cv::InterpolationFlags
+ *        The interpulation to use.
+ *
+ * @param cropped_image - cv::Mat &
+ *        The cropped image to resize
+ *
+ * @param resized_image - cv::Mat &
+ *        The resized image container to fill
+ *        (dims for resizing are assumed from here)
+ *
+ * @param roi - HailoROIPtr
+ *        ROI to resize in, used in inheriting classes
+ * @param image_format - GstVideoFormat
+ *        The format of the matrices.
+ */
+void resize_normal(cv::InterpolationFlags method,
+                   std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec,
+                   GstVideoFormat image_format)
+{
+    cv::Mat cropped_image = cropped_image_vec[0];
+    cv::Mat resized_image = resized_image_vec[0];
+    switch (image_format)
+    {
+    case GST_VIDEO_FORMAT_YUY2:
+    {
+        resize_yuy2(cropped_image, resized_image, method);
+        break;
+    }
+    case GST_VIDEO_FORMAT_NV12:
+    {
+        resize_nv12(cropped_image_vec, resized_image_vec, method);
+        break;
+    }
+    default:
+    {
+        cv::resize(cropped_image, resized_image, cv::Size(resized_image.cols, resized_image.rows), 0, 0, method);
+        break;
+    }
+    }
+}
+
+/**
+ * @brief Resize the an image using Letterbox strategy
+ *        Supports RGB/BGR
+ *
+ * @param method - cv::InterpolationFlags
+ *        The interpulation to use.
+ *
+ * @param cropped_image - cv::Mat &
+ *        The cropped image to resize
+ *
+ * @param resized_image - cv::Mat &
+ *        The resized image container to fill
+ *        (dims for resizing are assumed from here)
+ *
+ * @param roi - HailoROIPtr
+ *        ROI to resize in, used to update scaling bbox
+ *
+ * @param image_format - GstVideoFormat
+ *        The format of the matrices.
+ */
+void resize_letterbox(cv::InterpolationFlags method,
+                      std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec,
+                      HailoROIPtr roi, GstVideoFormat image_format,
+                      bool no_scaling_bbox)
+{
+    switch (image_format)
+    {
+    case GST_VIDEO_FORMAT_NV12:
+    {
+        static const cv::Scalar color(130, 130, 130);
+        HailoBBox letterboxed_scale = resize_letterbox_nv12(cropped_image_vec, resized_image_vec, color, method);
+        if (!no_scaling_bbox)
+            roi->set_scaling_bbox(letterboxed_scale);
+        break;
+    }
+    case GST_VIDEO_FORMAT_RGBA:
+    case GST_VIDEO_FORMAT_RGB:
+    {
+        static const cv::Scalar color(114, 114, 114);
+        HailoBBox letterboxed_scale = resize_letterbox_rgb(cropped_image_vec[0], resized_image_vec[0], color, method);
+        if (!no_scaling_bbox)
+            roi->set_scaling_bbox(letterboxed_scale);
+        break;
+    }
+    default:
+    {
+        std::cerr << "Letterbox resizing is supported only for RGB at this moment." << std::endl;
+        break;
+    }
+    }
+}

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
@@ -352,12 +352,16 @@ gst_hailo_basecropper_get_property(GObject *object, guint prop_id,
 
 /**
  * Retrieves wanted caps from downstream elements and sets them.
+ * Falls back to @fallback_caps when the downstream peer accepts ANY caps
+ * (e.g. a fakesink), avoiding the gst_caps_fixate(ANY) assertion.
  *
- * @param[in] hailo_basecropper      Pointer to the element, used to send caps query on the crop pad.
+ * @param[in] hailo_basecropper  Pointer to the element.
+ * @param[in] fallback_caps      Caps to use when the peer returns ANY; typically
+ *                               the incoming sink caps.  Not consumed (caller owns).
  * @return Upon success, returns true. Otherwise, returns false.
  */
 static gboolean
-gst_crop_scale_setcaps(GstHailoBaseCropper *hailo_basecropper)
+gst_crop_scale_setcaps(GstHailoBaseCropper *hailo_basecropper, GstCaps *fallback_caps)
 {
     GstCaps *caps_result, *outcaps = NULL;
     GstQuery *query = NULL;
@@ -369,12 +373,25 @@ gst_crop_scale_setcaps(GstHailoBaseCropper *hailo_basecropper)
     gst_pad_peer_query(hailo_basecropper->srcpad_crop, query);
     gst_query_parse_caps_result(query, &caps_result);
 
-    // Fixate the caps
-    // gst_caps_fixate takes ownership of caps_result, no need to unref it.
-    outcaps = gst_caps_fixate(caps_result);
+    // If the peer returned ANY caps (e.g. fakesink accepts everything), fall
+    // back to the incoming caps so that gst_caps_fixate never sees ANY.
+    if (!caps_result || gst_caps_is_any(caps_result))
+    {
+        GST_DEBUG_OBJECT(hailo_basecropper,
+                         "Crop peer returned ANY caps; using fallback caps %" GST_PTR_FORMAT,
+                         fallback_caps);
+        outcaps = gst_caps_copy(fallback_caps);
+    }
+    else
+    {
+        // Fixate the caps
+        // gst_caps_fixate takes ownership of caps_result, no need to unref it.
+        outcaps = gst_caps_fixate(caps_result);
+    }
 
     // Set The caps, unref all objects and return.
     gboolean ret = gst_pad_set_caps(hailo_basecropper->srcpad_crop, outcaps);
+    gst_caps_unref(outcaps);
     gst_query_unref(query);
 
     return ret;
@@ -499,7 +516,7 @@ gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
             return FALSE;
         }
 
-        ret = gst_crop_scale_setcaps(hailo_basecropper);
+        ret = gst_crop_scale_setcaps(hailo_basecropper, caps);
         if (!ret)
         {
             GST_ERROR_OBJECT(hailo_basecropper, "Unable to set caps on crop srcpad");

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2026 Hailo Technologies Ltd. All rights reserved.
+ * Copyright (c) 2021-2022 Hailo Technologies Ltd. All rights reserved.
  * Distributed under the LGPL license (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
  **/
 #include <gst/gst.h>
@@ -11,14 +11,18 @@
 #include <vector>
 #include <map>
 #include <typeinfo>
-#include "common/image.hpp"
-#include "hailomat_internal.hpp"
-#include "cropping/gsthailobasecropper.hpp"
+#include "image.hpp"
+#include "gsthailobasecropper.hpp"
 #include "gst_hailo_cropping_meta.hpp"
 #include "gst_hailo_stream_meta.hpp"
 #include "hailo_objects.hpp"
 #include "hailo_common.hpp"
 #include "gst_hailo_meta.hpp"
+#ifdef HAILO15_TARGET
+#include "buffer_utils.hpp"
+#include "media_library/dsp_utils.hpp"
+#include "gsthailodspbufferpoolutils.hpp"
+#endif
 
 GST_DEBUG_CATEGORY_STATIC(gst_hailo_basecropper_debug);
 #define GST_CAT_DEFAULT gst_hailo_basecropper_debug
@@ -30,6 +34,10 @@ enum
     PROP_DROP_UNCROPPED_BUFFERS,
     PROP_CROPPING_PERIOD,
     PROP_FILTER_STREAMS,
+#ifdef HAILO15_TARGET
+    PROP_USE_DSP,
+    PROP_POOL_SIZE,
+#endif
 };
 
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE("sink",
@@ -73,6 +81,12 @@ static gboolean gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hai
 
 static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size);
 
+#ifdef HAILO15_TARGET
+static gboolean dsp_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
+                                    GstBuffer *input_buffer, GstVideoInfo *input_video_info, GstBuffer *output_buffer, GstVideoInfo *output_video_info);
+static gboolean gst_hailo_basecropper_propose_allocation(GstHailoBaseCropper *hailo_basecropper, GstPad *pad, GstQuery *query);
+#endif
+
 static void
 gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
 {
@@ -107,6 +121,18 @@ gst_hailo_basecropper_class_init(GstHailoBaseCropperClass *klass)
                                                                              (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)),
                                                          (GParamFlags)(G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS)));
 
+#ifdef HAILO15_TARGET
+    g_object_class_install_property(gobject_class, PROP_USE_DSP,
+                                    g_param_spec_boolean("use-dsp", "Use DSP",
+                                                         "Whether to use DSP for cropping. Default true.", true,
+                                                         (GParamFlags)(GST_PARAM_CONTROLLABLE | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+    g_object_class_install_property(gobject_class, PROP_POOL_SIZE,
+                                    g_param_spec_uint("pool-size", "Pool Size",
+                                                      "Size of the pool of buffers to use for cropping. Default 10",
+                                                      1, G_MAXINT, 10,
+                                                      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
+#endif
+
     gst_element_class_add_pad_template(gstelement_class,
                                        gst_static_pad_template_get(&main_src_factory));
     gst_element_class_add_pad_template(gstelement_class,
@@ -138,6 +164,11 @@ gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
     gst_pad_set_query_function(hailo_basecropper->srcpad_crop, GST_DEBUG_FUNCPTR(gst_hailo_basecropper_src_query));
 
 // Set default values.
+#ifdef HAILO15_TARGET
+    hailo_basecropper->use_dsp = true;
+    hailo_basecropper->bufferpool_max_size = 10;
+    hailo_basecropper->bufferpool_min_size = 1;
+#endif
     hailo_basecropper->use_internal_offset = false;
     hailo_basecropper->internal_offset = 0;
     hailo_basecropper->cropping_period = 1;
@@ -148,6 +179,19 @@ gst_hailo_basecropper_init(GstHailoBaseCropper *hailo_basecropper)
     for (uint i = 0; i < GST_HAILO_CROPPER_MAX_FILTER_STREAMS; i++)
         hailo_basecropper->filter_streams[i] = "";
 }
+
+#ifdef HAILO15_TARGET
+static gboolean
+gst_hailo_basecropper_propose_allocation(GstHailoBaseCropper *hailo_basecropper, GstPad *pad, GstQuery *query)
+{
+    gboolean ret = gst_pad_peer_query(hailo_basecropper->srcpad_main, query);
+    if (!ret)
+        GST_DEBUG_OBJECT(hailo_basecropper, "Peer query allocation failed");
+    gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, NULL);
+
+    return true;
+}
+#endif
 
 static void gst_hailo_basecropper_dispose(GObject *object)
 {
@@ -169,6 +213,23 @@ gst_hailo_basecropper_decide_allocation(GstHailoBaseCropper *hailo_basecropper, 
 {
     gboolean ret = TRUE;
 
+#ifdef HAILO15_TARGET
+    if (!hailo_basecropper->use_dsp)
+        return ret;
+
+    GST_DEBUG_OBJECT(hailo_basecropper, "Performing decide allocation");
+
+    GstElement *element = GST_ELEMENT_CAST(hailo_basecropper);
+    hailo_basecropper->buffer_pool = gst_create_hailo_dsp_bufferpool_from_allocation_query(element, query, hailo_basecropper->bufferpool_min_size, hailo_basecropper->bufferpool_max_size, 0);
+    if (hailo_basecropper->buffer_pool == NULL)
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Decide Allocation - Failed to create buffer pool");
+        return FALSE;
+    }
+
+    GST_INFO_OBJECT(hailo_basecropper, "Decide allocation - hailo buffer pool created");
+
+#endif
     return ret;
 }
 
@@ -241,6 +302,14 @@ gst_hailo_basecropper_set_property(GObject *object, guint prop_id,
     case PROP_FILTER_STREAMS:
         set_filter_streams(hailo_basecropper, value);
         break;
+#ifdef HAILO15_TARGET
+    case PROP_USE_DSP:
+        hailo_basecropper->use_dsp = g_value_get_boolean(value);
+        break;
+    case PROP_POOL_SIZE:
+        hailo_basecropper->bufferpool_max_size = g_value_get_uint(value);
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
         break;
@@ -267,6 +336,14 @@ gst_hailo_basecropper_get_property(GObject *object, guint prop_id,
     case PROP_FILTER_STREAMS:
         get_filter_streams(hailo_basecropper, value);
         break;
+#ifdef HAILO15_TARGET
+    case PROP_USE_DSP:
+        g_value_set_boolean(value, hailo_basecropper->use_dsp);
+        break;
+    case PROP_POOL_SIZE:
+        g_value_set_uint(value, hailo_basecropper->bufferpool_max_size);
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
         break;
@@ -369,7 +446,13 @@ gst_hailo_basecropper_sink_query(GstPad *pad,
     case GST_QUERY_ALLOCATION:
     {
         GST_DEBUG_OBJECT(hailo_basecropper, "Received allocation query from sinkpad in hailo_basecropper");
+#ifdef HAILO15_TARGET
+        ret = gst_hailo_basecropper_propose_allocation(hailo_basecropper, pad, query);
+        if (!ret)
+            GST_DEBUG_OBJECT(hailo_basecropper, "Failed to query peer srcpad_main");
+#else
         ret = gst_pad_query_default(pad, parent, query);
+#endif
         break;
     }
     case GST_QUERY_ACCEPT_CAPS:
@@ -468,17 +551,146 @@ gst_hailo_basecropper_sink_event(GstPad *pad, GstObject *parent,
     return ret;
 }
 
+#ifdef HAILO15_TARGET
+dsp_interpolation_type_t get_dsp_interpolation_type_from_cv(GstHailoBaseCropper *hailo_basecropper, cv::InterpolationFlags interpolation)
+{
+    switch (interpolation)
+    {
+    case cv::INTER_NEAREST:
+        return INTERPOLATION_TYPE_NEAREST_NEIGHBOR;
+    case cv::INTER_LINEAR:
+        return INTERPOLATION_TYPE_BILINEAR;
+    case cv::INTER_AREA:
+        return INTERPOLATION_TYPE_AREA;
+    case cv::INTER_CUBIC:
+        return INTERPOLATION_TYPE_BICUBIC;
+    default:
+        GST_ERROR_OBJECT(hailo_basecropper, "Unsupported interpolation type %d", interpolation);
+        std::cerr << "Unsupported interpolation type " << interpolation << std::endl;
+        return INTERPOLATION_TYPE_BILINEAR;
+    }
+}
+#endif
+
 static GstBuffer *gst_hailo_basecropper_allocate_new_buffer(GstHailoBaseCropper *hailo_basecropper, size_t buffer_size)
 {
     GstBuffer *output_buffer = NULL;
+
+#ifdef HAILO15_TARGET
+    if (hailo_basecropper->use_dsp)
+    {
+        if (!hailo_basecropper->buffer_pool)
+        {
+            GST_ERROR_OBJECT(hailo_basecropper, "DSP buffer allocation requested form pool - but buffer pool is not initialized");
+            return NULL;
+        }
+        GstFlowReturn ret = GST_FLOW_OK;
+        ret = gst_buffer_pool_acquire_buffer(GST_BUFFER_POOL(hailo_basecropper->buffer_pool), &output_buffer, NULL);
+        if (ret != GST_FLOW_OK)
+        {
+            GST_ERROR_OBJECT(hailo_basecropper, "Failed to acquire buffer from pool");
+            return NULL;
+        }
+    }
+    else
+    {
+        output_buffer = gst_buffer_new_allocate(NULL, buffer_size, NULL);
+    }
+#else
     output_buffer = gst_buffer_new_allocate(NULL, buffer_size, NULL);
+#endif
+
     return output_buffer;
 }
+
+#ifdef HAILO15_TARGET
+static gboolean dsp_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, cv::Rect crop_rect, std::shared_ptr<HailoMat> resized_image,
+                                    GstBuffer *input_buffer, GstVideoInfo *input_video_info, GstBuffer *output_buffer, GstVideoInfo *output_video_info)
+{
+    dsp_utils::crop_resize_dims_t crop_resize_dims = {
+        .perform_crop = 1,
+        .crop_start_x = (size_t)crop_rect.x,
+        .crop_end_x = (size_t)crop_rect.x + crop_rect.width,
+        .crop_start_y = (size_t)crop_rect.y,
+        .crop_end_y = (size_t)crop_rect.y + crop_rect.height,
+        .destination_width = (size_t)resized_image->native_width(),
+        .destination_height = (size_t)resized_image->native_height(),
+    };
+
+    int input_width = GST_VIDEO_INFO_WIDTH(input_video_info);
+    int input_height = GST_VIDEO_INFO_HEIGHT(input_video_info);
+
+    // Map input and output buffers to GstVideoFrame
+    GstVideoFrame input_video_frame;
+    if (!gst_video_frame_map(&input_video_frame, input_video_info, input_buffer, GST_MAP_READ))
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Cannot map input buffer to frame");
+        throw std::runtime_error("Cannot map input buffer to frame");
+    }
+
+    if (!gst_buffer_is_writable(output_buffer))
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Output buffer is not writable");
+        throw std::runtime_error("Output buffer is not writable");
+    }
+
+    GstVideoFrame output_video_frame;
+    if (!gst_video_frame_map(&output_video_frame, output_video_info, output_buffer, GST_MAP_READWRITE))
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Cannot map output buffer to frame");
+        throw std::runtime_error("Cannot map output buffer to frame");
+    }
+    GstVideoFormat format = GST_VIDEO_FRAME_FORMAT(&input_video_frame);
+
+    // If the crop rect is the same as the input image (whole buffer), we request a resize only
+    if (crop_rect.x == 0 && crop_rect.y == 0 && crop_rect.width == input_width && crop_rect.height == input_height)
+    {
+        crop_resize_dims.perform_crop = 0;
+        GST_DEBUG_OBJECT(hailo_basecropper, "DSP Resize (Format: %d): Input Width: %d, Height: %d. \
+                                            Resize target Width: %ld Height: %ld",
+                         format, input_width, input_height,
+                         crop_resize_dims.destination_width, crop_resize_dims.destination_height);
+    }
+    else
+    {
+        GST_DEBUG_OBJECT(hailo_basecropper, "DSP Crop + Resize (Format: %d): Input Width: %d, Height: %d. \
+                                            Target Crop shape X: %d Y: %d Width: %d Height: %d. and Resize target Width: %ld Height: %ld",
+                         format, input_width, input_height, crop_rect.x, crop_rect.y, crop_rect.width, crop_rect.height,
+                         crop_resize_dims.destination_width, crop_resize_dims.destination_height);
+    }
+
+    // Create dsp image properties from both input and output video frame objects
+    dsp_image_properties_t input_image_properties;
+    dsp_image_properties_t output_image_properties;
+    create_dsp_buffer_from_video_frame(&input_video_frame, input_image_properties);
+    create_dsp_buffer_from_video_frame(&output_video_frame, output_image_properties);
+
+    // Perform the crop and resize
+    dsp_status result = dsp_utils::perform_crop_and_resize(&input_image_properties, &output_image_properties,
+                                                            crop_resize_dims,
+                                                            get_dsp_interpolation_type_from_cv(hailo_basecropper, cv::InterpolationFlags::INTER_LINEAR),
+                                                            std::nullopt);
+
+    // Free resources
+    dsp_utils::free_image_property_planes(&input_image_properties);
+    dsp_utils::free_image_property_planes(&output_image_properties);
+    gst_video_frame_unmap(&input_video_frame);
+    gst_video_frame_unmap(&output_video_frame);
+
+    if (result != DSP_SUCCESS)
+    {
+        GST_ERROR_OBJECT(hailo_basecropper, "Failed to perform dsp resize. return status: %d", result);
+        return false;
+    }
+
+    return true;
+}
+#endif
 
 static gboolean opencv_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, std::shared_ptr<HailoMat> resized_image, std::shared_ptr<HailoMat> full_image, GstVideoInfo *full_image_info, HailoROIPtr crop_roi)
 {
     GstHailoBaseCropperClass *hailo_basecropperclass = GST_HAILO_BASE_CROPPER_GET_CLASS(hailo_basecropper);
-    std::vector<cv::Mat>& resized_cv_mat = get_cv_matrices(*resized_image);
+    std::vector<cv::Mat> resized_cv_mat = resized_image->get_matrices();
 
     GST_DEBUG_OBJECT(hailo_basecropper, "Opencv Crop + Resize: Input Width: %d, Height: %d. \
                     Target Crop shape X: %f Y: %f Width: %f Height: %f. \
@@ -486,7 +698,7 @@ static gboolean opencv_crop_and_resize(GstHailoBaseCropper *hailo_basecropper, s
                      full_image->width(), full_image->height(),
                      crop_roi->get_bbox().xmin(), crop_roi->get_bbox().ymin(),
                      crop_roi->get_bbox().width(), crop_roi->get_bbox().height(), resized_cv_mat[0].cols, resized_cv_mat[0].rows);
-    std::vector<cv::Mat> cropped_cv_mat = crop_to_cv_matrices(*full_image, crop_roi);
+    std::vector<cv::Mat> cropped_cv_mat = full_image->crop(crop_roi);
 
     GstVideoFormat image_format = GST_VIDEO_INFO_FORMAT(full_image_info);
     hailo_basecropperclass->resize(hailo_basecropper, cropped_cv_mat, resized_cv_mat, crop_roi, image_format);
@@ -580,7 +792,19 @@ static GstBuffer *handle_one_crop(GstHailoBaseCropper *hailo_basecropper, GstBuf
     std::shared_ptr<HailoMat> resized_image = get_mat_by_format(output_buffer, resized_image_info);
 
 // Crop and resize the frame
+#ifdef HAILO15_TARGET
+    if (hailo_basecropper->use_dsp)
+    {
+        cv::Rect crop_rect = full_image->get_crop_rect(crop_roi);
+        dsp_crop_and_resize(hailo_basecropper, crop_rect, resized_image, input_buffer, full_image_info, output_buffer, resized_image_info);
+    }
+    else
+    {
+        opencv_crop_and_resize(hailo_basecropper, resized_image, full_image, full_image_info, crop_roi);
+    }
+#else
     opencv_crop_and_resize(hailo_basecropper, resized_image, full_image, full_image_info, crop_roi);
+#endif
 
     GST_DEBUG_OBJECT(hailo_basecropper, "Crop and resize done, freeing resources and returning buffer");
 

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2021-2026 Hailo Technologies Ltd. All rights reserved.
+* Copyright (c) 2021-2022 Hailo Technologies Ltd. All rights reserved.
 * Distributed under the LGPL license (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 **/
 #pragma once
@@ -35,6 +35,11 @@ struct _GstHailoBaseCropper
     gboolean drop_uncropped_buffers;
     uint internal_offset;
     uint cropping_period;
+    #ifdef HAILO15_TARGET
+    bool use_dsp;
+    guint bufferpool_max_size;
+    guint bufferpool_min_size;
+    #endif
     GstBufferPool *buffer_pool;
     uint num_streams_to_filter = 0;
     GstPad *sinkpad, *srcpad_crop, *srcpad_main;

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
@@ -11,24 +11,24 @@
 
 G_BEGIN_DECLS
 
-#define GST_TYPE_HAILO_BASE_CROPPER (gst_hailo_basecropper_get_type())
-#define GST_HAILO_BASE_CROPPER(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_HAILO_BASE_CROPPER, GstHailoBaseCropper))
-#define GST_HAILO_BASE_CROPPER_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_HAILO_BASE_CROPPER, GstHailoBaseCropperClass))
-#define GST_IS_HAILO_BASE_CROPPER(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_HAILO_BASE_CROPPER))
-#define GST_IS_HAILO_BASE_CROPPER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_HAILO_BASE_CROPPER))
-#define GST_HAILO_BASE_CROPPER_CAST(obj) ((GstHailoBaseCropper *)obj)
-#define GST_HAILO_BASE_CROPPER_GET_CLASS(obj) \
-        (G_TYPE_INSTANCE_GET_CLASS ((obj),GST_TYPE_HAILO_BASE_CROPPER,GstHailoBaseCropperClass))
+#define GST_TYPE_HAILO_BASE_CROPPER_DYN (gst_hailo_basecropper_dyn_get_type())
+#define GST_HAILO_BASE_CROPPER_DYN(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_HAILO_BASE_CROPPER_DYN, GstHailoBaseCropperDyn))
+#define GST_HAILO_BASE_CROPPER_DYN_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_HAILO_BASE_CROPPER_DYN, GstHailoBaseCropperDynClass))
+#define GST_IS_HAILO_BASE_CROPPER_DYN(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_HAILO_BASE_CROPPER_DYN))
+#define GST_IS_HAILO_BASE_CROPPER_DYN_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_HAILO_BASE_CROPPER_DYN))
+#define GST_HAILO_BASE_CROPPER_DYN_CAST(obj) ((GstHailoBaseCropperDyn *)obj)
+#define GST_HAILO_BASE_CROPPER_DYN_GET_CLASS(obj) \
+        (G_TYPE_INSTANCE_GET_CLASS ((obj),GST_TYPE_HAILO_BASE_CROPPER_DYN,GstHailoBaseCropperDynClass))
 
 #define GST_HAILO_CROPPER_MAX_FILTER_STREAMS 40
-#define HAILO_BASE_CROPPER_SUPPORTED_FORMATS "{ RGB, RGBA, YUY2, NV12 }"
-#define HAILO_BASE_CROPPER_VIDEO_CAPS \
-    GST_VIDEO_CAPS_MAKE(HAILO_BASE_CROPPER_SUPPORTED_FORMATS)
+#define HAILO_BASE_CROPPER_SUPPORTED_FORMATS_DYN "{ RGB, RGBA, YUY2, NV12 }"
+#define HAILO_BASE_CROPPER_VIDEO_CAPS_DYN \
+    GST_VIDEO_CAPS_MAKE(HAILO_BASE_CROPPER_SUPPORTED_FORMATS_DYN)
 
-typedef struct _GstHailoBaseCropper GstHailoBaseCropper;
-typedef struct _GstHailoBaseCropperClass GstHailoBaseCropperClass;
+typedef struct _GstHailoBaseCropperDyn GstHailoBaseCropperDyn;
+typedef struct _GstHailoBaseCropperDynClass GstHailoBaseCropperDynClass;
 
-struct _GstHailoBaseCropper
+struct _GstHailoBaseCropperDyn
 {
     GstElement element;
     gboolean use_internal_offset;
@@ -47,15 +47,15 @@ struct _GstHailoBaseCropper
     const gchar *filter_streams[GST_HAILO_CROPPER_MAX_FILTER_STREAMS];
 };
 
-struct _GstHailoBaseCropperClass
+struct _GstHailoBaseCropperDynClass
 {
     GstElementClass parent_class;
 
-    std::vector<HailoROIPtr> (*prepare_crops) (GstHailoBaseCropper *hailocropper,  GstBuffer *buf);
-    void (*resize) (GstHailoBaseCropper *basecropper, std::vector<cv::Mat> &cropped_image, std::vector<cv::Mat> &resized_image, HailoROIPtr roi, GstVideoFormat image_format);
+    std::vector<HailoROIPtr> (*prepare_crops) (GstHailoBaseCropperDyn *hailocropper,  GstBuffer *buf);
+    void (*resize) (GstHailoBaseCropperDyn *basecropper, std::vector<cv::Mat> &cropped_image, std::vector<cv::Mat> &resized_image, HailoROIPtr roi, GstVideoFormat image_format);
 };
 
-G_GNUC_INTERNAL GType gst_hailo_basecropper_get_type(void);
+G_GNUC_INTERNAL GType gst_hailo_basecropper_dyn_get_type(void);
 void resize_normal(cv::InterpolationFlags method, std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec, GstVideoFormat image_format);
 void resize_letterbox(cv::InterpolationFlags method, std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec, HailoROIPtr roi, GstVideoFormat image_format, bool no_scaling_bbox);
 

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailobasecropper.hpp
@@ -1,0 +1,57 @@
+/**
+* Copyright (c) 2021-2026 Hailo Technologies Ltd. All rights reserved.
+* Distributed under the LGPL license (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+**/
+#pragma once
+#include <map>
+#include <gst/gst.h>
+#include <gst/video/video-format.h>
+#include <opencv2/opencv.hpp>
+#include "hailo_objects.hpp"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_HAILO_BASE_CROPPER (gst_hailo_basecropper_get_type())
+#define GST_HAILO_BASE_CROPPER(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_HAILO_BASE_CROPPER, GstHailoBaseCropper))
+#define GST_HAILO_BASE_CROPPER_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_HAILO_BASE_CROPPER, GstHailoBaseCropperClass))
+#define GST_IS_HAILO_BASE_CROPPER(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_HAILO_BASE_CROPPER))
+#define GST_IS_HAILO_BASE_CROPPER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_HAILO_BASE_CROPPER))
+#define GST_HAILO_BASE_CROPPER_CAST(obj) ((GstHailoBaseCropper *)obj)
+#define GST_HAILO_BASE_CROPPER_GET_CLASS(obj) \
+        (G_TYPE_INSTANCE_GET_CLASS ((obj),GST_TYPE_HAILO_BASE_CROPPER,GstHailoBaseCropperClass))
+
+#define GST_HAILO_CROPPER_MAX_FILTER_STREAMS 40
+#define HAILO_BASE_CROPPER_SUPPORTED_FORMATS "{ RGB, RGBA, YUY2, NV12 }"
+#define HAILO_BASE_CROPPER_VIDEO_CAPS \
+    GST_VIDEO_CAPS_MAKE(HAILO_BASE_CROPPER_SUPPORTED_FORMATS)
+
+typedef struct _GstHailoBaseCropper GstHailoBaseCropper;
+typedef struct _GstHailoBaseCropperClass GstHailoBaseCropperClass;
+
+struct _GstHailoBaseCropper
+{
+    GstElement element;
+    gboolean use_internal_offset;
+    gboolean drop_uncropped_buffers;
+    uint internal_offset;
+    uint cropping_period;
+    GstBufferPool *buffer_pool;
+    uint num_streams_to_filter = 0;
+    GstPad *sinkpad, *srcpad_crop, *srcpad_main;
+    std::map<std::string, int> stream_ids_buff_offset;
+    const gchar *filter_streams[GST_HAILO_CROPPER_MAX_FILTER_STREAMS];
+};
+
+struct _GstHailoBaseCropperClass
+{
+    GstElementClass parent_class;
+
+    std::vector<HailoROIPtr> (*prepare_crops) (GstHailoBaseCropper *hailocropper,  GstBuffer *buf);
+    void (*resize) (GstHailoBaseCropper *basecropper, std::vector<cv::Mat> &cropped_image, std::vector<cv::Mat> &resized_image, HailoROIPtr roi, GstVideoFormat image_format);
+};
+
+G_GNUC_INTERNAL GType gst_hailo_basecropper_get_type(void);
+void resize_normal(cv::InterpolationFlags method, std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec, GstVideoFormat image_format);
+void resize_letterbox(cv::InterpolationFlags method, std::vector<cv::Mat> &cropped_image_vec, std::vector<cv::Mat> &resized_image_vec, HailoROIPtr roi, GstVideoFormat image_format, bool no_scaling_bbox);
+
+G_END_DECLS

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
@@ -27,7 +27,7 @@ GST_DEBUG_CATEGORY_STATIC(gst_hailotilecropper_dynamic_debug);
 #define gst_hailotilecropper_dynamic_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE(GstHailoTileCropperDynamic,
                         gst_hailotilecropper_dynamic,
-                        GST_TYPE_HAILO_BASE_CROPPER,
+                        GST_TYPE_HAILO_BASE_CROPPER_DYN,
                         _do_init);
 
 enum
@@ -44,11 +44,11 @@ static void gst_hailotilecropper_dynamic_get_property(GObject *o, guint id,
 static void gst_hailotilecropper_dynamic_finalize(GObject *o);
 
 static std::vector<HailoROIPtr>
-gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuffer *buf);
+gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropperDyn *cropper, GstBuffer *buf);
 
 /* Pass-through resize: same as TAPPAS hailotilecropper does. */
 static void
-hailotilecropper_dynamic_resize(GstHailoBaseCropper *,
+hailotilecropper_dynamic_resize(GstHailoBaseCropperDyn *,
                                 std::vector<cv::Mat> &cropped,
                                 std::vector<cv::Mat> &resized,
                                 HailoROIPtr,
@@ -103,7 +103,7 @@ gst_hailotilecropper_dynamic_class_init(GstHailoTileCropperDynamicClass *klass)
 {
     GObjectClass             *gobject_class    = G_OBJECT_CLASS(klass);
     GstElementClass          *gstelement_class = GST_ELEMENT_CLASS(klass);
-    GstHailoBaseCropperClass *base_class       = (GstHailoBaseCropperClass *)klass;
+    GstHailoBaseCropperDynClass *base_class       = (GstHailoBaseCropperDynClass *)klass;
 
     gobject_class->set_property = gst_hailotilecropper_dynamic_set_property;
     gobject_class->get_property = gst_hailotilecropper_dynamic_get_property;
@@ -206,7 +206,7 @@ gst_hailotilecropper_dynamic_get_property(GObject *object, guint prop_id,
  * downstream hailotileaggregator sees the same set we cropped.
  */
 static std::vector<HailoROIPtr>
-gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuffer *buf)
+gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropperDyn *cropper, GstBuffer *buf)
 {
     GstHailoTileCropperDynamic *self = GST_HAILO_TILE_CROPPER_DYNAMIC(cropper);
 

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
@@ -81,8 +81,19 @@ parse_static_tiles(const gchar *raw)
             try { vals[idx++] = std::stof(field); }
             catch (const std::exception &) { idx = -1; break; }
         }
-        if (idx == 4 && vals[2] > 0 && vals[3] > 0)
-            out.push_back({vals[0], vals[1], vals[2], vals[3]});
+        /* I1: bounds-check to [0,1] with small float epsilon. */
+        constexpr float kEps = 1e-4f;
+        bool valid = (idx == 4
+                      && vals[2] > 0 && vals[3] > 0
+                      && vals[0] >= -kEps && vals[1] >= -kEps
+                      && vals[0] + vals[2] <= 1.0f + kEps
+                      && vals[1] + vals[3] <= 1.0f + kEps);
+        /* I2: warn on malformed/out-of-range entries instead of silently dropping. */
+        if (!valid) {
+            GST_WARNING("Skipping malformed tile entry: '%s'", tile_str.c_str());
+            continue;
+        }
+        out.push_back({vals[0], vals[1], vals[2], vals[3]});
     }
     return out;
 }
@@ -203,8 +214,14 @@ gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuff
     std::vector<HailoROIPtr> crops;
 
     /* 1. Dynamic tiles: HailoTileROI objects pre-attached to main_roi. */
-    for (auto &obj : main_roi->get_objects_typed(HAILO_TILE))
-        crops.push_back(std::dynamic_pointer_cast<HailoROI>(obj));
+    for (auto &obj : main_roi->get_objects_typed(HAILO_TILE)) {
+        /* I4: guard against a non-HailoROI HAILO_TILE object (defensive cast). */
+        auto roi = std::dynamic_pointer_cast<HailoROI>(obj);
+        if (roi) crops.push_back(std::move(roi));
+    }
+
+    /* I3: capture dynamic count explicitly before appending static tiles. */
+    const size_t dynamic_count = crops.size();
 
     /* 2. Static tiles: snapshot under lock so set_property mid-flight is safe. */
     std::vector<StaticTile> snapshot;
@@ -235,7 +252,7 @@ gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuff
     GST_LOG_OBJECT(self,
         "prepare_crops: %zu tile(s) (%zu dynamic + %zu static)",
         crops.size(),
-        crops.size() - snapshot.size(),
+        dynamic_count,
         snapshot.size());
 
     return crops;

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp
@@ -1,0 +1,272 @@
+/*
+ * gsthailotilecropper_dynamic.cpp
+ *
+ * Derived from TAPPAS hailotilecropper (LGPL-2.1).
+ * Copyright (c) 2021-2026 Hailo Technologies Ltd. (base class & reference impl)
+ * Copyright (c) 2026 hailo-apps-infra contributors (this derivative)
+ *
+ * Distributed under the LGPL-2.1 license.
+ */
+#include <gst/gst.h>
+#include <opencv2/opencv.hpp>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gsthailotilecropper_dynamic.hpp"
+#include "gst_hailo_meta.hpp"
+#include "hailo_common.hpp"
+
+GST_DEBUG_CATEGORY_STATIC(gst_hailotilecropper_dynamic_debug);
+#define GST_CAT_DEFAULT gst_hailotilecropper_dynamic_debug
+#define _do_init \
+    GST_DEBUG_CATEGORY_INIT(gst_hailotilecropper_dynamic_debug, \
+                            "hailotilecropper_dynamic", 0, \
+                            "hailotilecropper_dynamic element");
+
+#define gst_hailotilecropper_dynamic_parent_class parent_class
+G_DEFINE_TYPE_WITH_CODE(GstHailoTileCropperDynamic,
+                        gst_hailotilecropper_dynamic,
+                        GST_TYPE_HAILO_BASE_CROPPER,
+                        _do_init);
+
+enum
+{
+    PROP_0,
+    PROP_TILES_STATIC,   /* "x,y,w,h;x,y,w,h;..." (normalized 0..1) */
+    PROP_ALLOW_EMPTY,    /* allow producing zero crops without warning */
+};
+
+static void gst_hailotilecropper_dynamic_set_property(GObject *o, guint id,
+                                                      const GValue *v, GParamSpec *p);
+static void gst_hailotilecropper_dynamic_get_property(GObject *o, guint id,
+                                                      GValue *v, GParamSpec *p);
+static void gst_hailotilecropper_dynamic_finalize(GObject *o);
+
+static std::vector<HailoROIPtr>
+gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuffer *buf);
+
+/* Pass-through resize: same as TAPPAS hailotilecropper does. */
+static void
+hailotilecropper_dynamic_resize(GstHailoBaseCropper *,
+                                std::vector<cv::Mat> &cropped,
+                                std::vector<cv::Mat> &resized,
+                                HailoROIPtr,
+                                GstVideoFormat fmt)
+{
+    resize_normal(cv::INTER_LINEAR, cropped, resized, fmt);
+}
+
+/* Parse `tiles-static`: "x,y,w,h;x,y,w,h" — whitespace allowed. */
+static std::vector<StaticTile>
+parse_static_tiles(const gchar *raw)
+{
+    std::vector<StaticTile> out;
+    if (!raw || !*raw)
+        return out;
+
+    std::string s(raw);
+    std::stringstream ss(s);
+    std::string tile_str;
+    while (std::getline(ss, tile_str, ';'))
+    {
+        if (tile_str.empty())
+            continue;
+        std::stringstream ts(tile_str);
+        std::string field;
+        float vals[4] = {0, 0, 0, 0};
+        int idx = 0;
+        while (idx < 4 && std::getline(ts, field, ','))
+        {
+            try { vals[idx++] = std::stof(field); }
+            catch (const std::exception &) { idx = -1; break; }
+        }
+        if (idx == 4 && vals[2] > 0 && vals[3] > 0)
+            out.push_back({vals[0], vals[1], vals[2], vals[3]});
+    }
+    return out;
+}
+
+static void
+gst_hailotilecropper_dynamic_class_init(GstHailoTileCropperDynamicClass *klass)
+{
+    GObjectClass             *gobject_class    = G_OBJECT_CLASS(klass);
+    GstElementClass          *gstelement_class = GST_ELEMENT_CLASS(klass);
+    GstHailoBaseCropperClass *base_class       = (GstHailoBaseCropperClass *)klass;
+
+    gobject_class->set_property = gst_hailotilecropper_dynamic_set_property;
+    gobject_class->get_property = gst_hailotilecropper_dynamic_get_property;
+    gobject_class->finalize     = gst_hailotilecropper_dynamic_finalize;
+
+    base_class->prepare_crops = gst_hailotilecropper_dynamic_prepare_crops;
+    base_class->resize        = hailotilecropper_dynamic_resize;
+
+    gst_element_class_set_static_metadata(
+        gstelement_class,
+        "hailotilecropper_dynamic - Dynamic Tiling",
+        "Hailo/Tools",
+        "Crops tiles defined dynamically by upstream pipeline elements and/or statically by properties",
+        "hailo-apps-infra contributors <noreply@hailo.ai>");
+
+    g_object_class_install_property(
+        gobject_class, PROP_TILES_STATIC,
+        g_param_spec_string(
+            "tiles-static", "Static tiles",
+            "Semicolon-separated list of static tile rectangles, normalized to "
+            "[0,1] of the frame. Format: 'x,y,w,h;x,y,w,h'. Static tiles are "
+            "appended to dynamic tiles read from the buffer's HailoROI on every "
+            "frame. Empty string disables static tiles.",
+            "",
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(
+        gobject_class, PROP_ALLOW_EMPTY,
+        g_param_spec_boolean(
+            "allow-empty", "Allow empty",
+            "If TRUE (default), buffers with zero tiles produce zero crop-pad "
+            "outputs (bypass-only). If FALSE, log a warning when no tiles are produced.",
+            TRUE,
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+}
+
+static void
+gst_hailotilecropper_dynamic_init(GstHailoTileCropperDynamic *self)
+{
+    self->tiles_static_str = g_strdup("");
+    new (&self->static_tiles) std::vector<StaticTile>();  /* placement-new */
+    self->allow_empty = TRUE;
+}
+
+static void
+gst_hailotilecropper_dynamic_finalize(GObject *object)
+{
+    GstHailoTileCropperDynamic *self = GST_HAILO_TILE_CROPPER_DYNAMIC(object);
+    g_free(self->tiles_static_str);
+    self->static_tiles.~vector<StaticTile>();
+    G_OBJECT_CLASS(gst_hailotilecropper_dynamic_parent_class)->finalize(object);
+}
+
+static void
+gst_hailotilecropper_dynamic_set_property(GObject *object, guint prop_id,
+                                          const GValue *value, GParamSpec *pspec)
+{
+    GstHailoTileCropperDynamic *self = GST_HAILO_TILE_CROPPER_DYNAMIC(object);
+    switch (prop_id)
+    {
+    case PROP_TILES_STATIC: {
+        GST_OBJECT_LOCK(self);
+        g_free(self->tiles_static_str);
+        self->tiles_static_str = g_value_dup_string(value);
+        self->static_tiles = parse_static_tiles(self->tiles_static_str);
+        GST_INFO_OBJECT(self, "Parsed %zu static tile(s)", self->static_tiles.size());
+        GST_OBJECT_UNLOCK(self);
+        break;
+    }
+    case PROP_ALLOW_EMPTY:
+        self->allow_empty = g_value_get_boolean(value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static void
+gst_hailotilecropper_dynamic_get_property(GObject *object, guint prop_id,
+                                          GValue *value, GParamSpec *pspec)
+{
+    GstHailoTileCropperDynamic *self = GST_HAILO_TILE_CROPPER_DYNAMIC(object);
+    switch (prop_id)
+    {
+    case PROP_TILES_STATIC:
+        GST_OBJECT_LOCK(self);
+        g_value_set_string(value, self->tiles_static_str);
+        GST_OBJECT_UNLOCK(self);
+        break;
+    case PROP_ALLOW_EMPTY:
+        g_value_set_boolean(value, self->allow_empty);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+/* Override: collect dynamic tiles already on the parent ROI, append static
+ * tiles, return everything. Each static tile is *added* to the ROI so the
+ * downstream hailotileaggregator sees the same set we cropped.
+ */
+static std::vector<HailoROIPtr>
+gst_hailotilecropper_dynamic_prepare_crops(GstHailoBaseCropper *cropper, GstBuffer *buf)
+{
+    GstHailoTileCropperDynamic *self = GST_HAILO_TILE_CROPPER_DYNAMIC(cropper);
+
+    HailoROIPtr main_roi = get_hailo_main_roi(buf, /*create_if_missing=*/true);
+    std::vector<HailoROIPtr> crops;
+
+    /* 1. Dynamic tiles: HailoTileROI objects pre-attached to main_roi. */
+    for (auto &obj : main_roi->get_objects_typed(HAILO_TILE))
+        crops.push_back(std::dynamic_pointer_cast<HailoROI>(obj));
+
+    /* 2. Static tiles: snapshot under lock so set_property mid-flight is safe. */
+    std::vector<StaticTile> snapshot;
+    {
+        GST_OBJECT_LOCK(self);
+        snapshot = self->static_tiles;
+        GST_OBJECT_UNLOCK(self);
+    }
+    uint next_index = static_cast<uint>(crops.size());
+    for (auto &t : snapshot)
+    {
+        auto tile = std::make_shared<HailoTileROI>(
+            HailoBBox(t.x, t.y, t.w, t.h),
+            next_index++,
+            /*overlap_x_axis=*/0.0f,
+            /*overlap_y_axis=*/0.0f,
+            /*layer=*/0,
+            /*mode=*/SINGLE_SCALE);
+        main_roi->add_object(tile);
+        crops.push_back(tile);
+    }
+
+    if (crops.empty() && !self->allow_empty)
+        GST_WARNING_OBJECT(self,
+            "Buffer %p produced zero tiles and allow-empty=false",
+            (void *)buf);
+
+    GST_LOG_OBJECT(self,
+        "prepare_crops: %zu tile(s) (%zu dynamic + %zu static)",
+        crops.size(),
+        crops.size() - snapshot.size(),
+        snapshot.size());
+
+    return crops;
+}
+
+/* ============================================================================
+ * Plugin registration (mirrors gsthailooverlay_community.cpp pattern)
+ * ============================================================================ */
+
+static gboolean
+plugin_init(GstPlugin *plugin)
+{
+    return gst_element_register(plugin,
+                                "hailotilecropper_dynamic",
+                                GST_RANK_PRIMARY,
+                                GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC);
+}
+
+#ifndef PACKAGE
+#define PACKAGE "hailotilecropper_dynamic"
+#endif
+#ifndef PACKAGE_VERSION
+#define PACKAGE_VERSION "0.1.0"
+#endif
+
+GST_PLUGIN_DEFINE(GST_VERSION_MAJOR,
+                  GST_VERSION_MINOR,
+                  hailotilecropper_dynamic,
+                  "Dynamic tile cropper for Hailo pipelines",
+                  plugin_init,
+                  PACKAGE_VERSION,
+                  "LGPL",
+                  "hailo-apps-infra",
+                  "https://github.com/hailo-ai/hailo-apps-infra")

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.hpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.hpp
@@ -48,7 +48,7 @@ struct StaticTile
 
 struct _GstHailoTileCropperDynamic
 {
-    GstHailoBaseCropper hailo_cropper;     /* base */
+    GstHailoBaseCropperDyn hailo_cropper;     /* base */
     gchar              *tiles_static_str;  /* property: raw "x,y,w,h;..." */
     std::vector<StaticTile> static_tiles;  /* parsed cache */
     gboolean            allow_empty;       /* property: if FALSE, log a warning when no tiles produced */
@@ -56,7 +56,7 @@ struct _GstHailoTileCropperDynamic
 
 struct _GstHailoTileCropperDynamicClass
 {
-    GstHailoBaseCropperClass parent_class;
+    GstHailoBaseCropperDynClass parent_class;
 };
 
 GType gst_hailotilecropper_dynamic_get_type(void);

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.hpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/gsthailotilecropper_dynamic.hpp
@@ -1,0 +1,64 @@
+/*
+ * gsthailotilecropper_dynamic.hpp
+ *
+ * GStreamer element: hailotilecropper_dynamic
+ *
+ * Crops tiles based on HailoTileROI sub-objects pre-attached to the buffer's
+ * main ROI (dynamic, set by upstream pipeline elements) plus optional static
+ * tiles configured via the `tiles-static` property.
+ *
+ * Derived from TAPPAS hailotilecropper (LGPL-2.1).
+ * Copyright (c) 2021-2026 Hailo Technologies Ltd. (base class & reference impl)
+ * Copyright (c) 2026 hailo-apps-infra contributors (this derivative)
+ *
+ * Distributed under the LGPL-2.1 license.
+ */
+#pragma once
+
+#include <gst/gst.h>
+#include <vector>
+#include "gsthailobasecropper.hpp"
+#include "hailo_objects.hpp"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC (gst_hailotilecropper_dynamic_get_type())
+#define GST_HAILO_TILE_CROPPER_DYNAMIC(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC, GstHailoTileCropperDynamic))
+#define GST_HAILO_TILE_CROPPER_DYNAMIC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC, GstHailoTileCropperDynamicClass))
+#define GST_IS_HAILO_TILE_CROPPER_DYNAMIC(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC))
+#define GST_IS_HAILO_TILE_CROPPER_DYNAMIC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC))
+
+typedef struct _GstHailoTileCropperDynamic      GstHailoTileCropperDynamic;
+typedef struct _GstHailoTileCropperDynamicClass GstHailoTileCropperDynamicClass;
+
+/* One static tile parsed from the `tiles-static` property string.
+ * All values are normalized [0.0, 1.0] (fraction of frame).
+ */
+struct StaticTile
+{
+    float x;
+    float y;
+    float w;
+    float h;
+};
+
+struct _GstHailoTileCropperDynamic
+{
+    GstHailoBaseCropper hailo_cropper;     /* base */
+    gchar              *tiles_static_str;  /* property: raw "x,y,w,h;..." */
+    std::vector<StaticTile> static_tiles;  /* parsed cache */
+    gboolean            allow_empty;       /* property: if FALSE, log a warning when no tiles produced */
+};
+
+struct _GstHailoTileCropperDynamicClass
+{
+    GstHailoBaseCropperClass parent_class;
+};
+
+GType gst_hailotilecropper_dynamic_get_type(void);
+
+G_END_DECLS

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/conftest.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/conftest.py
@@ -1,4 +1,5 @@
 """Shared fixtures for hailotilecropper_dynamic E2E tests."""
+import ctypes
 import os
 import pathlib
 import pytest
@@ -7,21 +8,54 @@ INSTALLED_PLUGIN = pathlib.Path(
     "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthailotilecropper_dynamic.so"
 )
 
+# Build-dir fallback: prefer this .so when it is newer than the installed one.
+# __file__ is at: <repo>/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/
+# parents[6] = repo root
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[6]  # …/hailo-apps-infra
+BUILD_PLUGIN = (
+    _REPO_ROOT / "hailo_apps" / "postprocess" / "build.release" / "cpp"
+    / "libgsthailotilecropper_dynamic.so"
+)
+
+
+def _preferred_plugin() -> pathlib.Path | None:
+    """Return the .so to use (None if neither exists)."""
+    if BUILD_PLUGIN.exists() and INSTALLED_PLUGIN.exists():
+        if BUILD_PLUGIN.stat().st_mtime > INSTALLED_PLUGIN.stat().st_mtime:
+            return BUILD_PLUGIN
+        return INSTALLED_PLUGIN
+    if BUILD_PLUGIN.exists():
+        return BUILD_PLUGIN
+    if INSTALLED_PLUGIN.exists():
+        return INSTALLED_PLUGIN
+    return None
+
 
 @pytest.fixture(scope="session", autouse=True)
-def _ensure_plugin_installed():
-    if not INSTALLED_PLUGIN.exists():
+def _preload_plugin():
+    """Preload the freshest hailotilecropper_dynamic .so before Gst.init().
+
+    Loading via ctypes with RTLD_GLOBAL before GStreamer initialises ensures
+    that GstHailoBaseCropperDyn is registered first.  GStreamer deduplicates
+    plugins by name, so the system .so (which may still carry the old
+    GstHailoBaseCropper) is silently skipped during the registry scan.
+    This lets the test suite exercise the freshly compiled binary without
+    requiring root privileges to install it.
+    """
+    plugin_path = _preferred_plugin()
+    if plugin_path is None:
         pytest.skip(
-            f"Plugin not installed at {INSTALLED_PLUGIN}. "
+            f"Plugin not found at {INSTALLED_PLUGIN} or {BUILD_PLUGIN}. "
             "Run `hailo-compile-postprocess` first."
         )
-    # Force GStreamer to rescan in case the plugin was just installed.
+    # Force-load our .so into the process before anything calls Gst.init().
+    ctypes.CDLL(str(plugin_path), mode=ctypes.RTLD_GLOBAL)
     os.environ.setdefault("GST_REGISTRY_UPDATE", "yes")
     yield
 
 
 @pytest.fixture(scope="session")
-def gst():
+def gst(_preload_plugin):
     import gi
     gi.require_version("Gst", "1.0")
     from gi.repository import Gst

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/conftest.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for hailotilecropper_dynamic E2E tests."""
+import os
+import pathlib
+import pytest
+
+INSTALLED_PLUGIN = pathlib.Path(
+    "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthailotilecropper_dynamic.so"
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _ensure_plugin_installed():
+    if not INSTALLED_PLUGIN.exists():
+        pytest.skip(
+            f"Plugin not installed at {INSTALLED_PLUGIN}. "
+            "Run `hailo-compile-postprocess` first."
+        )
+    # Force GStreamer to rescan in case the plugin was just installed.
+    os.environ.setdefault("GST_REGISTRY_UPDATE", "yes")
+    yield
+
+
+@pytest.fixture(scope="session")
+def gst():
+    import gi
+    gi.require_version("Gst", "1.0")
+    from gi.repository import Gst
+    Gst.init(None)
+    return Gst

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_aggregator_compat.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_aggregator_compat.py
@@ -10,25 +10,20 @@ detections inside each tile's ROI between cropper and aggregator, then
 verify the aggregator's main-pad output ROI carries detections in global
 coords.
 
-KNOWN FAILURE — Task 18 required
----------------------------------
-This test FAILS with a GLib type-registration conflict:
+GType Conflict Resolution — Task 18 DONE
+-----------------------------------------
+The GLib type-registration conflict that previously prevented hailotilecropper_dynamic
+from coexisting with hailotileaggregator in the same process has been resolved.
 
-  GLib-GObject-WARNING: cannot register existing type 'GstHailoBaseCropper'
-  GStreamer-CRITICAL: gst_element_register: assertion 'g_type_is_a (type, GST_TYPE_ELEMENT)' failed
+Root cause was: hailotilecropper_dynamic bundled a copy of GstHailoBaseCropper which
+collided with the same type exported by libgsthailotools.so (hailotileaggregator's
+library).
 
-Root cause: hailotilecropper_dynamic bundles its own copy of GstHailoBaseCropper
-(compiled from TAPPAS upstream source).  libgsthailotools.so (which contains
-hailotileaggregator) also exports GstHailoBaseCropper.  GLib forbids registering
-a GType name twice; when both shared libraries are loaded in the same process our
-plugin fails to register its element type entirely, making the pipeline impossible
-to construct.  Even the element creation step (Gst.ElementFactory.make) hangs
-because the factory is left in a broken state.
-
-Consequence: hailotilecropper_dynamic cannot be used in the same GStreamer process
-as hailotileaggregator.  Task 18 (custom hailotileaggregator_dynamic plugin) is
-therefore REQUIRED.  The new aggregator must not inherit from GstHailoBaseCropper
-and must live in our own shared library.
+Fix (Task 18): the bundled base class was renamed from GstHailoBaseCropper to
+GstHailoBaseCropperDyn throughout the vendored source.  The freshly compiled .so
+is preloaded via ctypes before Gst.init() so its GType registers first; GStreamer
+then deduplicates the plugin by name and skips the stale system .so during the
+registry scan, eliminating the conflict entirely.
 """
 import pytest
 import subprocess
@@ -45,21 +40,48 @@ def _detect_type_conflict() -> str | None:
 
     Runs a sub-process that loads both plugins and reports any GLib critical
     warnings.  Returns None if no conflict is detected.
+
+    The probe always uses the freshest available .so (build-dir preferred over
+    the system-installed one) so that a successful rename in the source tree is
+    detectable even before `hailo-compile-postprocess` / `ninja install` has
+    been run with root privileges.
     """
-    probe_script = """\
-import gi, sys, warnings
+    import pathlib
+    # __file__ is at: <repo>/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/
+    # parents[6] = repo root
+    _repo_root = pathlib.Path(__file__).resolve().parents[6]
+    build_so = (
+        _repo_root / "hailo_apps" / "postprocess" / "build.release" / "cpp"
+        / "libgsthailotilecropper_dynamic.so"
+    )
+    system_so = pathlib.Path(
+        "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthailotilecropper_dynamic.so"
+    )
+    # Pick the newer of the two .sos; fall back gracefully.
+    if build_so.exists() and system_so.exists():
+        so_to_use = str(build_so if build_so.stat().st_mtime > system_so.stat().st_mtime else system_so)
+    elif build_so.exists():
+        so_to_use = str(build_so)
+    else:
+        so_to_use = str(system_so)
+
+    probe_script = f"""\
+import ctypes, gi, sys
+# Preload our .so BEFORE Gst.init() so that GstHailoBaseCropperDyn is registered
+# first.  GStreamer deduplicates plugins by name, so the stale system .so (which
+# still has the old GstHailoBaseCropper) is skipped during the registry scan and
+# no GType conflict occurs with libgsthailotools.so.
+so_path = "{so_to_use}"
+ctypes.CDLL(so_path, mode=ctypes.RTLD_GLOBAL)
+
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst
-
-# Capture GLib warnings
-import logging
-logging.captureWarnings(True)
 
 Gst.init(None)
 
 # Loading hailotileaggregator triggers libgsthailotools.so which registers
-# GstHailoBaseCropper.  Then querying for hailotilecropper_dynamic triggers
-# our plugin which tries to register the same type again.
+# GstHailoBaseCropper (the upstream type).  Our renamed plugin now registers
+# GstHailoBaseCropperDyn — a distinct GType — so there should be no conflict.
 factory_agg = Gst.ElementFactory.find('hailotileaggregator')
 factory_dyn = Gst.ElementFactory.find('hailotilecropper_dynamic')
 
@@ -100,26 +122,15 @@ sys.exit(0)
 # Decision-point test
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "GLib type-registration conflict: GstHailoBaseCropper is registered by "
-        "both libgsthailotilecropper_dynamic.so (bundled copy) and libgsthailotools.so "
-        "(hailotileaggregator's library).  The pipeline cannot be constructed.  "
-        "Task 18 (custom aggregator) is required to resolve this."
-    ),
-    strict=True,
-)
 def test_aggregator_merges_arbitrary_tile_layout(gst):
-    """Decision-point test: hailotileaggregator + hailotilecropper_dynamic compatibility.
+    """hailotileaggregator + hailotilecropper_dynamic coexistence and E2E test.
 
-    This test is marked xfail(strict=True).  It will:
-    - Pass (unexpected pass → xpass → ERROR) only if the conflict is resolved.
-    - Fail (expected xfail → XFAIL) while the conflict remains — documenting
-      that Task 18 (custom aggregator) is required.
+    Task 18 resolved the GLib type-registration conflict by renaming the bundled
+    base class from GstHailoBaseCropper to GstHailoBaseCropperDyn.  This test:
 
-    The test detects the conflict via a subprocess probe to avoid hanging the
-    main pytest process, then asserts no conflict exists (which will fail while
-    the conflict is present, producing the expected XFAIL result).
+    1. Verifies no GType conflict exists (subprocess probe).
+    2. Runs the full E2E pipeline: hailotilecropper_dynamic → hailotileaggregator
+       with synthetic detections to confirm coord translation + NMS work.
     """
     conflict = _detect_type_conflict()
     if conflict:

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_aggregator_compat.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_aggregator_compat.py
@@ -1,0 +1,188 @@
+"""E2E: hailotileaggregator works downstream of hailotilecropper_dynamic.
+
+The aggregator must:
+  1. Translate detection bboxes from each tile-local space → frame-global space.
+  2. Cross-tile NMS dedup.
+
+We feed a fixed test video, attach 2 non-grid tiles dynamically via the
+identity-handoff pattern, emulate inference output by attaching synthetic
+detections inside each tile's ROI between cropper and aggregator, then
+verify the aggregator's main-pad output ROI carries detections in global
+coords.
+
+KNOWN FAILURE — Task 18 required
+---------------------------------
+This test FAILS with a GLib type-registration conflict:
+
+  GLib-GObject-WARNING: cannot register existing type 'GstHailoBaseCropper'
+  GStreamer-CRITICAL: gst_element_register: assertion 'g_type_is_a (type, GST_TYPE_ELEMENT)' failed
+
+Root cause: hailotilecropper_dynamic bundles its own copy of GstHailoBaseCropper
+(compiled from TAPPAS upstream source).  libgsthailotools.so (which contains
+hailotileaggregator) also exports GstHailoBaseCropper.  GLib forbids registering
+a GType name twice; when both shared libraries are loaded in the same process our
+plugin fails to register its element type entirely, making the pipeline impossible
+to construct.  Even the element creation step (Gst.ElementFactory.make) hangs
+because the factory is left in a broken state.
+
+Consequence: hailotilecropper_dynamic cannot be used in the same GStreamer process
+as hailotileaggregator.  Task 18 (custom hailotileaggregator_dynamic plugin) is
+therefore REQUIRED.  The new aggregator must not inherit from GstHailoBaseCropper
+and must live in our own shared library.
+"""
+import pytest
+import subprocess
+import sys
+import os
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _detect_type_conflict() -> str | None:
+    """Return conflict description if the GLib type registration conflict is present.
+
+    Runs a sub-process that loads both plugins and reports any GLib critical
+    warnings.  Returns None if no conflict is detected.
+    """
+    probe_script = """\
+import gi, sys, warnings
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
+
+# Capture GLib warnings
+import logging
+logging.captureWarnings(True)
+
+Gst.init(None)
+
+# Loading hailotileaggregator triggers libgsthailotools.so which registers
+# GstHailoBaseCropper.  Then querying for hailotilecropper_dynamic triggers
+# our plugin which tries to register the same type again.
+factory_agg = Gst.ElementFactory.find('hailotileaggregator')
+factory_dyn = Gst.ElementFactory.find('hailotilecropper_dynamic')
+
+# If the dynamic factory is missing or broken, the conflict is present.
+if factory_dyn is None:
+    print("CONFLICT: hailotilecropper_dynamic factory not found after loading hailotileaggregator")
+    sys.exit(1)
+
+# Try to make both elements
+agg = factory_agg.create('agg') if factory_agg else None
+dyn = factory_dyn.create('tc') if factory_dyn else None
+
+if dyn is None:
+    print("CONFLICT: hailotilecropper_dynamic element could not be created")
+    sys.exit(1)
+
+print("OK: both elements created successfully")
+sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", probe_script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env={**os.environ, "GST_DEBUG": "2"},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0 or "CONFLICT" in combined:
+        conflict_lines = [
+            line for line in combined.splitlines()
+            if any(k in line for k in ("CONFLICT", "cannot register", "assertion", "CRITICAL", "WARNING"))
+        ]
+        return "\n".join(conflict_lines) if conflict_lines else "non-zero exit: " + combined[:400]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Decision-point test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason=(
+        "GLib type-registration conflict: GstHailoBaseCropper is registered by "
+        "both libgsthailotilecropper_dynamic.so (bundled copy) and libgsthailotools.so "
+        "(hailotileaggregator's library).  The pipeline cannot be constructed.  "
+        "Task 18 (custom aggregator) is required to resolve this."
+    ),
+    strict=True,
+)
+def test_aggregator_merges_arbitrary_tile_layout(gst):
+    """Decision-point test: hailotileaggregator + hailotilecropper_dynamic compatibility.
+
+    This test is marked xfail(strict=True).  It will:
+    - Pass (unexpected pass → xpass → ERROR) only if the conflict is resolved.
+    - Fail (expected xfail → XFAIL) while the conflict remains — documenting
+      that Task 18 (custom aggregator) is required.
+
+    The test detects the conflict via a subprocess probe to avoid hanging the
+    main pytest process, then asserts no conflict exists (which will fail while
+    the conflict is present, producing the expected XFAIL result).
+    """
+    conflict = _detect_type_conflict()
+    if conflict:
+        pytest.fail(
+            "GStHailoBaseCropper type-registration conflict detected — "
+            "hailotilecropper_dynamic cannot coexist with hailotileaggregator "
+            "in the same process.  Task 18 (custom hailotileaggregator_dynamic) "
+            f"is required.\n\nConflict evidence:\n{conflict}"
+        )
+
+    # If we reach here the conflict is resolved.  Now run the actual E2E test.
+    import hailo
+
+    pipeline_str = (
+        "videotestsrc num-buffers=2 ! "
+        "video/x-raw,format=RGB,width=128,height=96,framerate=30/1 ! "
+        "identity name=tile_setter signal-handoffs=true ! "
+        "hailotilecropper_dynamic name=tc "
+        "    tc.src_0 ! queue ! agg.sink_0 "
+        "    tc.src_1 ! queue ! identity name=fake_inf signal-handoffs=true ! agg.sink_1 "
+        "hailotileaggregator name=agg flatten-detections=true iou-threshold=0.3 "
+        "agg.src ! fakesink name=final_sink signal-handoffs=true sync=false async=false"
+    )
+    pipe = gst.parse_launch(pipeline_str)
+
+    def attach_tiles(identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        roi.add_object(hailo.HailoTileROI(
+            hailo.HailoBBox(0.0, 0.0, 0.5, 0.5), 0, 0.0, 0.0, 0, hailo.SINGLE_SCALE))
+        roi.add_object(hailo.HailoTileROI(
+            hailo.HailoBBox(0.4, 0.4, 0.6, 0.6), 1, 0.0, 0.0, 0, hailo.SINGLE_SCALE))
+
+    pipe.get_by_name("tile_setter").connect("handoff", attach_tiles)
+
+    def fake_inference(identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        det = hailo.HailoDetection(
+            hailo.HailoBBox(0.1, 0.1, 0.3, 0.3),
+            "synthetic", 0.9,
+        )
+        roi.add_object(det)
+
+    pipe.get_by_name("fake_inf").connect("handoff", fake_inference)
+
+    detections_per_frame = []
+
+    def on_final(_sink, buf, _pad):
+        roi = hailo.get_roi_from_buffer(buf)
+        dets = [obj for obj in roi.get_objects_typed(hailo.HAILO_DETECTION)]
+        detections_per_frame.append(dets)
+
+    pipe.get_by_name("final_sink").connect("handoff", on_final)
+    pipe.set_state(gst.State.PLAYING)
+    pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+
+    assert len(detections_per_frame) == 2
+    for dets in detections_per_frame:
+        assert len(dets) >= 1, "Aggregator dropped all detections"
+        for d in dets:
+            bb = d.get_bbox()
+            assert 0.0 <= bb.xmin() <= 1.0
+            assert 0.0 <= bb.ymin() <= 1.0
+            assert bb.width() > 0 and bb.height() > 0

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_combined.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_combined.py
@@ -1,0 +1,35 @@
+"""E2E: dynamic tiles from upstream + static tiles from property — both used."""
+import hailo
+
+
+def test_combined_static_plus_dynamic(gst):
+    pipe = gst.parse_launch(
+        "videotestsrc num-buffers=4 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "identity name=tile_setter signal-handoffs=true ! "
+        "hailotilecropper_dynamic name=tc "
+        "tiles-static=\"0.0,0.0,1.0,1.0;0.25,0.25,0.5,0.5\" "
+        "tc.src_0 ! fakesink sync=false async=false "
+        "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+    )
+    crop_count = [0]
+    pipe.get_by_name("crop_sink").connect(
+        "handoff", lambda sink, buf, pad: crop_count.__setitem__(0, crop_count[0] + 1)
+    )
+
+    def attach_one_dynamic(identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        roi.add_object(hailo.HailoTileROI(
+            hailo.HailoBBox(0.0, 0.0, 0.5, 0.5),
+            99, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
+        ))
+
+    pipe.get_by_name("tile_setter").connect("handoff", attach_one_dynamic)
+
+    pipe.set_state(gst.State.PLAYING)
+    pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+    # 1 dynamic + 2 static = 3 tiles per frame × 4 frames = 12
+    assert crop_count[0] == 12

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_dynamic_tiles.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_dynamic_tiles.py
@@ -1,0 +1,94 @@
+"""E2E: tiles attached upstream via the identity element's handoff signal.
+
+Mirrors the production pattern: an application callback (running inside
+hailofilter or equivalent) decides what to crop and attaches HailoTileROI
+objects to each buffer's main ROI before the buffer reaches the cropper.
+
+Implementation note
+-------------------
+Python pad probes (Gst.PadProbeType.BUFFER) receive a non-writable GstBuffer
+reference: GStreamer's PadProbeInfo holds an extra ref, so the buffer refcount
+is > 1 and gst_buffer_add_hailo_meta() refuses to add meta to it.  The
+``identity signal-handoffs=true`` pattern avoids this: the ``handoff`` signal
+fires while the buffer is being processed inside the identity chain function,
+where the refcount is 1 and the buffer is writable.
+"""
+import hailo
+
+
+def test_dynamic_tiles_via_handoff_signal(gst):
+    """4 tiles attached per frame via the identity handoff signal."""
+    pipeline_str = (
+        "videotestsrc num-buffers=6 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "identity name=tile_setter signal-handoffs=true ! "
+        "hailotilecropper_dynamic name=tc "
+        "tc.src_0 ! fakesink sync=false async=false "
+        "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+    )
+    pipe = gst.parse_launch(pipeline_str)
+
+    crop_count = [0]
+    pipe.get_by_name("crop_sink").connect(
+        "handoff",
+        lambda sink, buf, pad: crop_count.__setitem__(0, crop_count[0] + 1),
+    )
+
+    def attach_tiles(identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        for i in range(4):
+            tile = hailo.HailoTileROI(
+                hailo.HailoBBox(0.25 * (i % 2), 0.25 * (i // 2), 0.5, 0.5),
+                i, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
+            )
+            roi.add_object(tile)
+
+    pipe.get_by_name("tile_setter").connect("handoff", attach_tiles)
+
+    pipe.set_state(gst.State.PLAYING)
+    msg = pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+    assert msg is not None and msg.type == gst.MessageType.EOS
+    assert crop_count[0] == 24  # 6 frames × 4 dynamic tiles
+
+
+def test_variable_tile_count_per_frame(gst):
+    """Different number of tiles per frame — simulates dynamic app behavior."""
+    pipeline_str = (
+        "videotestsrc num-buffers=3 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "identity name=tile_setter signal-handoffs=true ! "
+        "hailotilecropper_dynamic name=tc "
+        "tc.src_0 ! fakesink sync=false async=false "
+        "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+    )
+    pipe = gst.parse_launch(pipeline_str)
+
+    crop_count = [0]
+    pipe.get_by_name("crop_sink").connect(
+        "handoff",
+        lambda sink, buf, pad: crop_count.__setitem__(0, crop_count[0] + 1),
+    )
+
+    frame_idx = [0]
+
+    def attach_variable(identity, buf):
+        roi = hailo.get_roi_from_buffer(buf)
+        for i in range(frame_idx[0] + 1):
+            tile = hailo.HailoTileROI(
+                hailo.HailoBBox(0.0, 0.0, 1.0, 1.0),
+                i, 0.0, 0.0, 0, hailo.SINGLE_SCALE,
+            )
+            roi.add_object(tile)
+        frame_idx[0] += 1
+
+    pipe.get_by_name("tile_setter").connect("handoff", attach_variable)
+
+    pipe.set_state(gst.State.PLAYING)
+    pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+    assert crop_count[0] == 1 + 2 + 3  # 6 total

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_no_tiles.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_no_tiles.py
@@ -1,0 +1,36 @@
+"""E2E: no tiles configured anywhere → crop pad receives zero buffers."""
+import pytest
+
+
+def _run_pipeline(gst, pipeline_str, expected_main, expected_crop):
+    pipe = gst.parse_launch(pipeline_str)
+    main_sink = pipe.get_by_name("main_sink")
+    crop_sink = pipe.get_by_name("crop_sink")
+
+    main_count, crop_count = [0], [0]
+    main_sink.connect("handoff", lambda *a: main_count.__setitem__(0, main_count[0] + 1))
+    crop_sink.connect("handoff", lambda *a: crop_count.__setitem__(0, crop_count[0] + 1))
+
+    pipe.set_state(gst.State.PLAYING)
+    msg = pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+    assert msg is not None and msg.type == gst.MessageType.EOS, "Pipeline did not reach EOS"
+    assert main_count[0] == expected_main
+    assert crop_count[0] == expected_crop
+
+
+def test_no_tiles_bypass_only(gst):
+    _run_pipeline(
+        gst,
+        pipeline_str=(
+            "videotestsrc num-buffers=10 ! "
+            "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+            "hailotilecropper_dynamic name=tc tiles-static=\"\" "
+            "tc.src_0 ! fakesink name=main_sink signal-handoffs=true sync=false "
+            "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+        ),
+        expected_main=10,
+        expected_crop=0,
+    )

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_static_tiles.py
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/e2e/test_e2e_static_tiles.py
@@ -1,0 +1,62 @@
+"""E2E: static tiles configured via property → N crops per buffer."""
+import pytest
+
+
+def _count_buffers(gst, pipeline_str):
+    pipe = gst.parse_launch(pipeline_str)
+    main_sink = pipe.get_by_name("main_sink")
+    crop_sink = pipe.get_by_name("crop_sink")
+    main_count, crop_count = [0], [0]
+    main_sink.connect("handoff", lambda *a: main_count.__setitem__(0, main_count[0] + 1))
+    crop_sink.connect("handoff", lambda *a: crop_count.__setitem__(0, crop_count[0] + 1))
+    pipe.set_state(gst.State.PLAYING)
+    msg = pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)
+    assert msg is not None and msg.type == gst.MessageType.EOS
+    return main_count[0], crop_count[0]
+
+
+def test_two_static_tiles_split_frame_in_half(gst):
+    main, crop = _count_buffers(gst,
+        "videotestsrc num-buffers=5 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "hailotilecropper_dynamic name=tc "
+        "tiles-static=\"0.0,0.0,0.5,1.0;0.5,0.0,0.5,1.0\" "
+        "tc.src_0 ! fakesink name=main_sink signal-handoffs=true sync=false async=false "
+        "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+    )
+    assert main == 5
+    assert crop == 10  # 5 frames × 2 tiles
+
+
+def test_three_overlapping_static_tiles(gst):
+    main, crop = _count_buffers(gst,
+        "videotestsrc num-buffers=4 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "hailotilecropper_dynamic name=tc "
+        "tiles-static=\"0.0,0.0,0.6,1.0;0.4,0.0,0.6,1.0;0.2,0.2,0.6,0.6\" "
+        "tc.src_0 ! fakesink name=main_sink signal-handoffs=true sync=false async=false "
+        "tc.src_1 ! fakesink name=crop_sink signal-handoffs=true sync=false async=false"
+    )
+    assert main == 4
+    assert crop == 12  # 4 frames × 3 tiles
+
+
+def test_property_change_at_runtime(gst):
+    pipe = gst.parse_launch(
+        "videotestsrc num-buffers=3 ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "hailotilecropper_dynamic name=tc "
+        "tc.src_0 ! fakesink sync=false "
+        "tc.src_1 ! fakesink sync=false async=false"
+    )
+    tc = pipe.get_by_name("tc")
+    tc.set_property("tiles-static", "0.0,0.0,1.0,1.0")
+    assert tc.get_property("tiles-static") == "0.0,0.0,1.0,1.0"
+    pipe.set_state(gst.State.PLAYING)
+    pipe.get_bus().timed_pop_filtered(
+        5 * gst.SECOND, gst.MessageType.EOS | gst.MessageType.ERROR
+    )
+    pipe.set_state(gst.State.NULL)

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/meson.build
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/meson.build
@@ -1,0 +1,24 @@
+unit_test_sources = {
+    'test_no_tiles_dyn'        : 'test_no_tiles.cpp',
+    'test_static_tiles_dyn'    : 'test_static_tiles.cpp',
+    'test_dynamic_tiles_dyn'   : 'test_dynamic_tiles.cpp',
+    'test_combined_tiles_dyn'  : 'test_combined_tiles.cpp',
+}
+
+# Link tests against the same plugin sources so we drive the element in-process.
+test_inc = include_directories('..', '../..')
+test_link_sources = files(
+    '../../gsthailobasecropper.cpp',
+    '../../gsthailotilecropper_dynamic.cpp',
+)
+
+foreach name, src : unit_test_sources
+    exe = executable(
+        name,
+        [src, test_link_sources],
+        include_directories : test_inc,
+        dependencies        : hailotilecropper_dynamic_deps + [gst_check_dep],
+        cpp_args            : ['-DBUILDING_TEST', '-DPACKAGE="hailotilecropper_dynamic"'],
+    )
+    test(name, exe, suite : 'hailotilecropper_dynamic')
+endforeach

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_combined_tiles.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_combined_tiles.cpp
@@ -1,0 +1,45 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <gst/gst.h>
+#include <gst/check/gstharness.h>
+#include "gst_hailo_meta.hpp"
+#include "hailo_objects.hpp"
+#include "gsthailotilecropper_dynamic.hpp"
+
+static void register_once()
+{
+    static gsize once = 0;
+    if (g_once_init_enter(&once)) {
+        gst_init(nullptr, nullptr);
+        gst_element_register(nullptr, "hailotilecropper_dynamic",
+                             GST_RANK_PRIMARY, GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC);
+        g_once_init_leave(&once, 1);
+    }
+}
+
+TEST_CASE("combined: dynamic tiles from buffer + static tiles from property")
+{
+    register_once();
+    GstHarness *h_main = gst_harness_new_with_padnames(
+        "hailotilecropper_dynamic", "sink", "src_0");
+    GstHarness *h_crop = gst_harness_new_with_element(
+        h_main->element, nullptr, "src_1");
+
+    g_object_set(h_main->element, "tiles-static", "0.0,0.0,1.0,1.0", nullptr);
+    gst_harness_set_src_caps_str(h_main,
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1");
+
+    GstBuffer *buf = gst_harness_create_buffer(h_main, 64 * 48 * 3);
+    HailoROIPtr roi = get_hailo_main_roi(buf, true);
+    roi->add_object(std::make_shared<HailoTileROI>(
+        HailoBBox(0.0f, 0.0f, 0.5f, 0.5f), 0, 0.0f, 0.0f, 0, SINGLE_SCALE));
+    roi->add_object(std::make_shared<HailoTileROI>(
+        HailoBBox(0.5f, 0.5f, 0.5f, 0.5f), 1, 0.0f, 0.0f, 0, SINGLE_SCALE));
+
+    REQUIRE(gst_harness_push(h_main, buf) == GST_FLOW_OK);
+    /* 2 dynamic + 1 static = 3 crops. */
+    REQUIRE(gst_harness_buffers_received(h_crop) == 3);
+
+    gst_harness_teardown(h_crop);
+    gst_harness_teardown(h_main);
+}

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_dynamic_tiles.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_dynamic_tiles.cpp
@@ -1,0 +1,46 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <gst/gst.h>
+#include <gst/check/gstharness.h>
+#include "gst_hailo_meta.hpp"
+#include "hailo_objects.hpp"
+#include "gsthailotilecropper_dynamic.hpp"
+
+static void register_once()
+{
+    static gsize once = 0;
+    if (g_once_init_enter(&once)) {
+        gst_init(nullptr, nullptr);
+        gst_element_register(nullptr, "hailotilecropper_dynamic",
+                             GST_RANK_PRIMARY, GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC);
+        g_once_init_leave(&once, 1);
+    }
+}
+
+TEST_CASE("dynamic tiles pre-attached to ROI produce one crop per tile")
+{
+    register_once();
+    GstHarness *h_main = gst_harness_new_with_padnames(
+        "hailotilecropper_dynamic", "sink", "src_0");
+    GstHarness *h_crop = gst_harness_new_with_element(
+        h_main->element, nullptr, "src_1");
+
+    gst_harness_set_src_caps_str(h_main,
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1");
+
+    GstBuffer *buf = gst_harness_create_buffer(h_main, 64 * 48 * 3);
+
+    /* Attach 3 dynamic tiles to the buffer's main ROI BEFORE pushing. */
+    HailoROIPtr roi = get_hailo_main_roi(buf, /*create=*/true);
+    for (int i = 0; i < 3; ++i) {
+        roi->add_object(std::make_shared<HailoTileROI>(
+            HailoBBox(0.1f * i, 0.1f * i, 0.3f, 0.3f),
+            i, 0.0f, 0.0f, 0, SINGLE_SCALE));
+    }
+
+    REQUIRE(gst_harness_push(h_main, buf) == GST_FLOW_OK);
+    REQUIRE(gst_harness_buffers_received(h_crop) == 3);
+
+    gst_harness_teardown(h_crop);
+    gst_harness_teardown(h_main);
+}

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_no_tiles.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_no_tiles.cpp
@@ -1,0 +1,38 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <gst/gst.h>
+#include <gst/check/gstharness.h>
+
+#include "gsthailotilecropper_dynamic.hpp"
+
+static void register_once()
+{
+    static gsize once = 0;
+    if (g_once_init_enter(&once)) {
+        gst_init(nullptr, nullptr);
+        gst_element_register(nullptr, "hailotilecropper_dynamic",
+                             GST_RANK_PRIMARY, GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC);
+        g_once_init_leave(&once, 1);
+    }
+}
+
+TEST_CASE("no tiles -> zero crop-pad outputs, one bypass output")
+{
+    register_once();
+    GstHarness *h_main = gst_harness_new_with_padnames(
+        "hailotilecropper_dynamic", "sink", "src_0");
+    GstHarness *h_crop = gst_harness_new_with_element(
+        h_main->element, nullptr, "src_1");
+
+    gst_harness_set_src_caps_str(h_main,
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1");
+
+    GstBuffer *buf = gst_harness_create_buffer(h_main, 64 * 48 * 3);
+    REQUIRE(gst_harness_push(h_main, buf) == GST_FLOW_OK);
+
+    REQUIRE(gst_harness_buffers_received(h_main) == 1);  /* bypass */
+    REQUIRE(gst_harness_buffers_received(h_crop) == 0);  /* no tiles */
+
+    gst_harness_teardown(h_crop);
+    gst_harness_teardown(h_main);
+}

--- a/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_static_tiles.cpp
+++ b/hailo_apps/postprocess/cpp/hailotilecropper_dynamic/tests/unit/test_static_tiles.cpp
@@ -1,0 +1,74 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <gst/gst.h>
+#include <gst/check/gstharness.h>
+#include "gst_hailo_meta.hpp"
+#include "hailo_objects.hpp"
+#include "gsthailotilecropper_dynamic.hpp"
+
+static void register_once()
+{
+    static gsize once = 0;
+    if (g_once_init_enter(&once)) {
+        gst_init(nullptr, nullptr);
+        gst_element_register(nullptr, "hailotilecropper_dynamic",
+                             GST_RANK_PRIMARY, GST_TYPE_HAILO_TILE_CROPPER_DYNAMIC);
+        g_once_init_leave(&once, 1);
+    }
+}
+
+TEST_CASE("static tiles -> N crop-pad outputs per buffer; HailoTileROI attached to bypass")
+{
+    register_once();
+    GstHarness *h_main = gst_harness_new_with_padnames(
+        "hailotilecropper_dynamic", "sink", "src_0");
+    GstHarness *h_crop = gst_harness_new_with_element(
+        h_main->element, nullptr, "src_1");
+
+    g_object_set(h_main->element,
+                 "tiles-static", "0.0,0.0,0.5,1.0;0.5,0.0,0.5,1.0",
+                 nullptr);
+    gst_harness_set_src_caps_str(h_main,
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1");
+
+    GstBuffer *buf = gst_harness_create_buffer(h_main, 64 * 48 * 3);
+    REQUIRE(gst_harness_push(h_main, buf) == GST_FLOW_OK);
+
+    REQUIRE(gst_harness_buffers_received(h_main) == 1);
+    REQUIRE(gst_harness_buffers_received(h_crop) == 2);
+
+    GstBuffer *out = gst_harness_pull(h_main);
+    HailoROIPtr roi = get_hailo_main_roi(out, /*create=*/false);
+    REQUIRE(roi != nullptr);
+    REQUIRE(roi->get_objects_typed(HAILO_TILE).size() == 2);
+    gst_buffer_unref(out);
+
+    gst_harness_teardown(h_crop);
+    gst_harness_teardown(h_main);
+}
+
+TEST_CASE("malformed static-tiles string is silently skipped (with WARNING)")
+{
+    register_once();
+    GstHarness *h_main = gst_harness_new_with_padnames(
+        "hailotilecropper_dynamic", "sink", "src_0");
+    GstHarness *h_crop = gst_harness_new_with_element(
+        h_main->element, nullptr, "src_1");
+
+    /* "not,a,tile" -> unparseable; "1.5,0.0,0.4,0.4" -> out-of-range x.
+     * Both should be rejected (with WARNING). The two valid ones survive. */
+    g_object_set(h_main->element,
+                 "tiles-static", "0.0,0.0,1.0,1.0;not,a,tile;1.5,0.0,0.4,0.4;0.1,0.1,0.4,0.4",
+                 nullptr);
+    gst_harness_set_src_caps_str(h_main,
+        "video/x-raw,format=RGB,width=32,height=32,framerate=30/1");
+
+    GstBuffer *buf = gst_harness_create_buffer(h_main, 32 * 32 * 3);
+    REQUIRE(gst_harness_push(h_main, buf) == GST_FLOW_OK);
+
+    /* 2 valid tiles => 2 crops; malformed and out-of-range are dropped. */
+    REQUIRE(gst_harness_buffers_received(h_crop) == 2);
+
+    gst_harness_teardown(h_crop);
+    gst_harness_teardown(h_main);
+}

--- a/hailo_apps/postprocess/cpp/meson.build
+++ b/hailo_apps/postprocess/cpp/meson.build
@@ -288,3 +288,8 @@ shared_library('gsthailotilecropper_dynamic',
     install : true,
     install_dir : gst_plugins_dir,
 )
+
+# Optional: build C++ unit tests for hailotilecropper_dynamic.
+if get_option('build_tests') and gst_check_dep.found()
+    subdir('hailotilecropper_dynamic/tests/unit')
+endif

--- a/hailo_apps/postprocess/cpp/meson.build
+++ b/hailo_apps/postprocess/cpp/meson.build
@@ -267,3 +267,24 @@ shared_library('ocr_postprocess',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
 )
+
+################################################
+# HAILOTILECROPPER_DYNAMIC (community GStreamer element)
+################################################
+hailotilecropper_dynamic_inc = include_directories('hailotilecropper_dynamic')
+
+hailotilecropper_dynamic_deps = [postprocess_dep, gst_dep, gst_base_dep, gst_video_dep]
+if opencv_dep.found()
+    hailotilecropper_dynamic_deps += opencv_dep
+endif
+
+shared_library('gsthailotilecropper_dynamic',
+    ['hailotilecropper_dynamic/gsthailobasecropper.cpp',
+     'hailotilecropper_dynamic/gsthailotilecropper_dynamic.cpp'],
+    include_directories : [hailotilecropper_dynamic_inc],
+    dependencies : hailotilecropper_dynamic_deps,
+    cpp_args : ['-DPACKAGE="hailotilecropper_dynamic"'],
+    gnu_symbol_visibility : 'default',
+    install : true,
+    install_dir : gst_plugins_dir,
+)

--- a/hailo_apps/postprocess/meson.build
+++ b/hailo_apps/postprocess/meson.build
@@ -15,6 +15,22 @@ endif
 
 zlib_dep = dependency('zlib', required : false)
 
+# GStreamer deps (used by community/overlay/cropper plugins).
+gst_dep        = dependency('gstreamer-1.0',          required : false)
+gst_base_dep   = dependency('gstreamer-base-1.0',     required : false)
+gst_video_dep  = dependency('gstreamer-video-1.0',    required : false)
+gst_check_dep  = dependency('gstreamer-check-1.0',    required : false)
+
+# Resolve GStreamer plugin install dir from pkg-config.
+gst_plugins_dir = '/usr/lib/gstreamer-1.0'
+if gst_dep.found()
+    gst_plugins_dir_result = run_command('pkg-config', '--variable=pluginsdir', 'gstreamer-1.0', check: false)
+    if gst_plugins_dir_result.returncode() == 0
+        gst_plugins_dir = gst_plugins_dir_result.stdout().strip()
+    endif
+endif
+message('GStreamer plugin install dir: @0@'.format(gst_plugins_dir))
+
 # Try to find OpenCV4 for static linking
 # Option 1: Prefer static OpenCV (if available)
 # Set static: true to prefer static libraries

--- a/hailo_apps/postprocess/meson_options.txt
+++ b/hailo_apps/postprocess/meson_options.txt
@@ -1,0 +1,2 @@
+option('build_tests', type : 'boolean', value : false,
+       description : 'Build C++ unit tests for community plugins.')


### PR DESCRIPTION
Running an object detector on a high-resolution frame on a Hailo NPU is bounded by inference budget per frame. The standard
  TAPPAS hailotilecropper only supports regular grids — every tile in the grid runs through the inference pipeline every frame, 
  regardless of whether anything interesting is in it. That spends inference budget uniformly across the frame even when most
  tiles contain nothing relevant.                                                                                               
                                                                                        
  hailotilecropper_dynamic lets the application steer the inference budget: crop tiles where signal is, skip the rest.          
  Concretely:
                                                                                                                                
  - Per-frame ROI tiles. A tracker / detector / external signal upstream attaches a tile around the actual object of interest   
  each frame — inference runs at native resolution on the part of the frame that matters, instead of on every grid cell.
  - Variable tile count. Spend zero inference calls when nothing's locked, one when there is, several when multiple ROIs are    
  active. No fixed grid cost.                                                                                                   
  - Static + dynamic combined. Keep a small fixed set of "always-on" coarse tiles for global scene awareness, layer high-detail
  dynamic tiles on top of that for the regions you care about. Effectively a coarse-to-fine inference budget.                   
  - Bypass-only mode. When no ROI is active, skip cropping entirely (sub-object stream empty, original buffer still passes
  through src_0) — no wasted inference at all without removing the element from the pipeline.                                   
                                                                                        
  Drop-in compatible with hailotileaggregator: same pad layout, same downstream contract. Lives at                              
  hailo_apps/postprocess/cpp/hailotilecropper_dynamic/.                                 
