### PR TITLE
fix: test infra, deps, config.json path resolution, and new test suites

### DIFF
--- a/hailo_apps/config/test_definition_config.yaml
+++ b/hailo_apps/config/test_definition_config.yaml
@@ -207,9 +207,7 @@ apps:
     script: "hailo_apps/python/standalone_apps/lane_detection/lane_detection.py"
     cli: ""
     default_test_suites:
-      - "basic_image_smoke"
-      - "basic_show_fps"
-      - "input_video_with_hef"
+      - "input_video_with_hef_no_fps"
     extra_test_suites: []
 
   super_resolution_standalone:
@@ -233,6 +231,42 @@ apps:
     default_test_suites:
       - "basic_image_smoke"
       - "basic_show_fps"
+    extra_test_suites: []
+
+  object_detection_onnx_postproc_standalone:
+    name: "YOLO26 Object Detection Standalone"
+    description: "Standalone yolo26 object detection (non-NMS, ONNX postproc)"
+    module: "hailo_apps.python.standalone_apps.yolo26.object_detection.object_detection_onnx_postproc"
+    script: "hailo_apps/python/standalone_apps/yolo26/object_detection/object_detection_onnx_postproc.py"
+    cli: ""
+    default_test_suites:
+      - "basic_image_smoke"
+      - "basic_show_fps"
+      - "input_video_with_hef"
+    extra_test_suites: []
+
+  pose_estimation_onnx_postproc_standalone:
+    name: "YOLO26 Pose Estimation Standalone"
+    description: "Standalone yolo26 pose estimation (non-NMS, ONNX postproc)"
+    module: "hailo_apps.python.standalone_apps.yolo26.pose_estimation.pose_estimation_onnx_postproc"
+    script: "hailo_apps/python/standalone_apps/yolo26/pose_estimation/pose_estimation_onnx_postproc.py"
+    cli: ""
+    default_test_suites:
+      - "basic_image_smoke"
+      - "basic_show_fps"
+      - "input_video_with_hef"
+    extra_test_suites: []
+
+  oriented_object_detection_standalone:
+    name: "Oriented Object Detection Standalone"
+    description: "Standalone oriented object detection app"
+    module: "hailo_apps.python.standalone_apps.oriented_object_detection.oriented_object_detection"
+    script: "hailo_apps/python/standalone_apps/oriented_object_detection/oriented_object_detection.py"
+    cli: ""
+    default_test_suites:
+      - "basic_image_smoke"
+      - "basic_show_fps"
+      - "input_video_with_hef"
     extra_test_suites: []
 
 # Test suites with flag combinations (aligned with FLAG_COMBINATIONS.md)
@@ -284,6 +318,14 @@ test_suites:
       - "${HEF_PATH}"
       - "--show-fps"
     description: "Video file with explicit HEF path"
+
+  input_video_with_hef_no_fps:
+    flags:
+      - "--input"
+      - "${VIDEO_PATH}"
+      - "--hef-path"
+      - "${HEF_PATH}"
+    description: "Video file with explicit HEF path (no --show-fps, for apps with minimal parsers)"
 
   input_usb_with_hef:
     flags:

--- a/hailo_apps/python/standalone_apps/oriented_object_detection/oriented_object_detection.py
+++ b/hailo_apps/python/standalone_apps/oriented_object_detection/oriented_object_detection.py
@@ -109,7 +109,7 @@ def run_inference_pipeline(
     """
 
     labels = get_labels(labels)
-    config_data = load_json_file("config.json")
+    config_data = load_json_file(str(Path(__file__).parent / "config.json"))
 
     stop_event = threading.Event()
     fps_tracker = None

--- a/hailo_apps/python/standalone_apps/yolo26/object_detection/object_detection_onnx_postproc.py
+++ b/hailo_apps/python/standalone_apps/yolo26/object_detection/object_detection_onnx_postproc.py
@@ -169,7 +169,7 @@ def run_inference_pipeline(net, input_src, batch_size, labels, output_dir,
     Initialize queues, HailoAsyncInference instance, and run the inference.
     """
     labels = get_labels(labels)
-    config_data = load_json_file("config.json")
+    config_data = load_json_file(str(Path(__file__).parent / "config.json"))
     
     # Load ONNX config and initialize sessions if specified
     onnx_session = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     # Core dependencies
-    "numpy",
+    "numpy<2",
     "setproctitle",
     "opencv-python<=4.10.0.84",  # Pin to avoid Qt font warnings in newer versions
     "python-dotenv",
@@ -32,6 +32,9 @@ dependencies = [
     "lap",
     "cython_bbox",
     "tqdm",
+
+    # ONNX postprocessing (yolo26 non-NMS apps)
+    "onnxruntime",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_control.yaml
+++ b/tests/test_control.yaml
@@ -88,6 +88,18 @@ logging:
         default: "./logs/standalone/paddle_ocr/default"
         extra: "./logs/standalone/paddle_ocr/extra"
         all: "./logs/standalone/paddle_ocr/all"
+      object_detection_onnx_postproc_standalone:
+        default: "./logs/standalone/yolo26_object_detection/default"
+        extra: "./logs/standalone/yolo26_object_detection/extra"
+        all: "./logs/standalone/yolo26_object_detection/all"
+      pose_estimation_onnx_postproc_standalone:
+        default: "./logs/standalone/yolo26_pose_estimation/default"
+        extra: "./logs/standalone/yolo26_pose_estimation/extra"
+        all: "./logs/standalone/yolo26_pose_estimation/all"
+      oriented_object_detection_standalone:
+        default: "./logs/standalone/oriented_object_detection/default"
+        extra: "./logs/standalone/oriented_object_detection/extra"
+        all: "./logs/standalone/oriented_object_detection/all"
 
 # ============================================================================
 # Test combinations configuration
@@ -206,6 +218,18 @@ standalone_tests:
       test_suite_mode: "default"
       model_selection: "default"
       description: "Standalone Paddle OCR (smoke + show-fps only)"
+    object_detection_onnx_postproc_standalone:
+      test_suite_mode: "default"
+      model_selection: "default"
+      description: "Standalone yolo26 object detection (non-NMS)"
+    pose_estimation_onnx_postproc_standalone:
+      test_suite_mode: "default"
+      model_selection: "default"
+      description: "Standalone yolo26 pose estimation (non-NMS)"
+    oriented_object_detection_standalone:
+      test_suite_mode: "default"
+      model_selection: "default"
+      description: "Standalone oriented object detection"
 
 # GenAI tests configuration
 genai_tests:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -270,6 +270,9 @@ def run_pipeline_test(
         elif run_method == "pythonpath":
             stdout, stderr = run_func(pipeline_config["script"], args, log_file, **kwargs)
         elif run_method == "cli":
+            if not pipeline_config.get("cli"):
+                logger.info("Skipping cli run method: no cli path configured for this app")
+                return b"", b"", True
             stdout, stderr = run_func(pipeline_config["cli"], args, log_file, **kwargs)
         else:
             return b"", b"Invalid run method".encode(), False


### PR DESCRIPTION
- pin numpy<2 and add onnxruntime to pyproject.toml for SA apps
- fix config.json loaded relative to script dir, not cwd (oriented_object_detection, yolo26 OD)
- add input_video_with_hef_no_fps test suite for apps without --show-fps support
- fix lane_detection_standalone test to use video-only suite (no --show-fps flag)
- skip cli run method gracefully when cli field is empty string
- add coverage for standalone apps that were missing test suites