### PR TITLE
Feature/fix overlay community install

### DIFF
--- a/hailo_apps/installation/set_env.py
+++ b/hailo_apps/installation/set_env.py
@@ -245,6 +245,10 @@ def configure_environment(config: Dict, env_path: Path) -> None:
     # Get log level from config (default: INFO)
     log_level = config.get('log_level', 'INFO').upper()
     
+    # GStreamer plugin path for community overlay and other plugins installed
+    # to the repo-owned directory (avoids requiring root for system plugin dir).
+    gst_plugin_path = f"{RESOURCES_ROOT_PATH_DEFAULT}/so"
+
     # Build environment variables dict
     env_vars = {
         HOST_ARCH_KEY: host_arch,
@@ -258,6 +262,7 @@ def configure_environment(config: Dict, env_path: Path) -> None:
         VIRTUAL_ENV_NAME_KEY: venv_config.get('name', VIRTUAL_ENV_NAME_DEFAULT),
         HAILO_APPS_PATH_KEY: repo_root,
         HAILO_LOG_LEVEL_KEY: log_level,
+        "GST_PLUGIN_PATH": gst_plugin_path,
     }
     
     # Update os.environ

--- a/hailo_apps/postprocess/cpp/meson.build
+++ b/hailo_apps/postprocess/cpp/meson.build
@@ -38,7 +38,7 @@ yolov8pose_postprocess_sources = [
 ]
 shared_library('yolov8pose_postprocess',
     yolov8pose_postprocess_sources,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -53,7 +53,7 @@ yolov5seg_post_sources = [
 
 shared_library('yolov5seg_postprocess',
     yolov5seg_post_sources,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -68,7 +68,7 @@ depth_postprocess_sources = [
 ]
 shared_library('depth_postprocess',
     depth_postprocess_sources,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -107,7 +107,7 @@ scrfd_post_sources = [
 
 shared_library('scrfd',
     scrfd_post_sources,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -122,7 +122,7 @@ arcface_post_sources = [
 
 shared_library('face_recognition_post',
     arcface_post_sources,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -162,7 +162,7 @@ repvgg_reid_sources = [
 shared_library('repvgg_reid_postprocess',
     repvgg_reid_sources,
     include_directories : rapidjson_inc,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',
@@ -214,7 +214,7 @@ clip_sources = [
 shared_library('clip_postprocess',
     clip_sources,
     include_directories : rapidjson_inc,
-    dependencies : postprocess_dep,
+    dependencies : [postprocess_dep, hailo_common_compat_dep],
     gnu_symbol_visibility : 'default',
     install: true,
     install_dir: '/usr/local/hailo/resources/so',

--- a/hailo_apps/postprocess/cpp/meson.build
+++ b/hailo_apps/postprocess/cpp/meson.build
@@ -290,7 +290,7 @@ if yaml_cpp_dep.found() and gst_dep.found() and gst_base_dep.found() and gst_vid
         cpp_args : ['-DPACKAGE="hailooverlay_community"'],
         gnu_symbol_visibility : 'default',
         install: true,
-        install_dir: gst_plugins_dir,
+        install_dir: '/usr/local/hailo/resources/so',
     )
 else
     message('Skipping hailooverlay_community (missing yaml-cpp or GStreamer dependencies)')

--- a/hailo_apps/postprocess/cpp/overlay_community/overlay.cpp
+++ b/hailo_apps/postprocess/cpp/overlay_community/overlay.cpp
@@ -16,6 +16,24 @@
 #include "sprite_cache.hpp"
 #include "style_config.hpp"
 
+// TAPPAS 5.3.0 decoupled OpenCV types from HailoMat draw API.
+// Provide inline shims so the same source compiles on both 5.1.x and 5.3.x.
+#if __has_include("hailomat_internal.hpp")
+#include "hailomat_internal.hpp"   // provides get_cv_matrices()
+static inline hailo_point_t to_h(const cv::Point &p) { return {p.x, p.y}; }
+static inline hailo_rect_t to_h(const cv::Rect &r) { return {r.x, r.y, r.width, r.height}; }
+static inline hailo_size_t to_h(const cv::Size &s) { return {s.width, s.height}; }
+static inline hailo_scalar_t to_h(const cv::Scalar &s) { return {s[0], s[1], s[2], s[3]}; }
+#define GET_CV_MAT(hmat) get_cv_matrices(hmat)[0]
+#else
+// TAPPAS 5.1.x — cv:: types pass directly to HailoMat methods
+static inline const cv::Point& to_h(const cv::Point &p) { return p; }
+static inline const cv::Rect& to_h(const cv::Rect &r) { return r; }
+static inline const cv::Size& to_h(const cv::Size &s) { return s; }
+static inline const cv::Scalar& to_h(const cv::Scalar &s) { return s; }
+#define GET_CV_MAT(hmat) (hmat).get_matrices()[0]
+#endif
+
 #define SPACE " "
 #define TEXT_CLS_FONT_SCALE_FACTOR (0.0025f)
 #define MINIMUM_TEXT_CLS_FONT_SCALE (0.5f)
@@ -80,7 +98,7 @@ static overlay_status_t draw_classification(HailoMat &mat, HailoROIPtr roi, std:
     auto text_position = cv::Point(roi_xmin, roi_ymin + (TEXT_DEFAULT_HEIGHT * number_of_classifications * roi_height) + log(roi_height));
     double font_scale = TEXT_CLS_FONT_SCALE_FACTOR * roi_width;
     font_scale = (font_scale < MINIMUM_TEXT_CLS_FONT_SCALE) ? MINIMUM_TEXT_CLS_FONT_SCALE : font_scale;
-    mat.draw_text(text, text_position, font_scale, get_color(color_id));
+    mat.draw_text(text, to_h(text_position), font_scale, to_h(get_color(color_id)));
     return OVERLAY_STATUS_OK;
 }
 
@@ -141,7 +159,7 @@ static overlay_status_t draw_landmarks(HailoMat &hmat, HailoLandmarksPtr landmar
             cv::Point joint2 = cv::Point(x2, y2);
 
             thickness = (bbox.width() < 0.05) ? 1 : 2;
-            hmat.draw_line(joint1, joint2, get_color(4), thickness, cv::LINE_4);
+            hmat.draw_line(to_h(joint1), to_h(joint2), to_h(get_color(4)), thickness, cv::LINE_4);
         }
     }
 
@@ -165,14 +183,14 @@ static overlay_status_t draw_landmarks(HailoMat &hmat, HailoLandmarksPtr landmar
                     // Center sprite on keypoint
                     cv::Rect sprite_rect(x - sprite->cols / 2, y - sprite->rows / 2,
                                          sprite->cols, sprite->rows);
-                    draw_sprite(hmat.get_matrices()[0], sprite_rect, *sprite);
+                    draw_sprite(GET_CV_MAT(hmat), sprite_rect, *sprite);
                     continue;  // skip default dot
                 }
             }
         }
 
         auto center = cv::Point(x, y);
-        hmat.draw_ellipse(center, {R, R}, 0, 0, 360, get_color(7), landmark_point_radius);
+        hmat.draw_ellipse(to_h(center), to_h(cv::Size(R, R)), 0, 0, 360, to_h(get_color(7)), landmark_point_radius);
     }
     return OVERLAY_STATUS_OK;
 }
@@ -220,7 +238,7 @@ static overlay_status_t draw_tile(HailoMat &mat, HailoTileROIPtr tile)
     else
         color = get_color(DEFAULT_TILE_COLOR);
 
-    mat.draw_rectangle(rect, color);
+    mat.draw_rectangle(to_h(rect), to_h(color));
 
     return OVERLAY_STATUS_OK;
 }
@@ -237,7 +255,7 @@ static overlay_status_t draw_id(HailoMat &mat, HailoUniqueIDPtr &hailo_id, Hailo
 
     double font_scale = TEXT_FONT_FACTOR * log(bbox_width);
     auto text_position = cv::Point(bbox_min.x + log(bbox_width), bbox_max.y - log(bbox_width));
-    mat.draw_text(id_text, text_position, font_scale, color);
+    mat.draw_text(id_text, to_h(text_position), font_scale, to_h(color));
     return OVERLAY_STATUS_OK;
 }
 
@@ -407,7 +425,7 @@ overlay_status_t draw_all(HailoMat &hmat, HailoROIPtr roi, const OverlayParams &
 {
     overlay_status_t ret = OVERLAY_STATUS_UNINITIALIZED;
     uint number_of_classifications = 0;
-    cv::Mat &mat = hmat.get_matrices()[0];
+    cv::Mat &mat = GET_CV_MAT(hmat);
     for (auto obj : roi->get_objects())
     {
         switch (obj->get_type())
@@ -486,7 +504,7 @@ overlay_status_t draw_all(HailoMat &hmat, HailoROIPtr roi, const OverlayParams &
 
             // Bbox
             if (draw_bbox && !bbox_replaced_by_sprite)
-                hmat.draw_rectangle(rect, color);
+                hmat.draw_rectangle(to_h(rect), to_h(color));
 
             // Detection text
             if (draw_label && !bbox_replaced_by_sprite && !text.empty()) {
@@ -505,10 +523,10 @@ overlay_status_t draw_all(HailoMat &hmat, HailoROIPtr roi, const OverlayParams &
                         font_scale, 1, &baseline);
                     cv::Rect bg_rect(text_position.x, text_position.y - text_size.height,
                         text_size.width, text_size.height + baseline);
-                    cv::rectangle(hmat.get_matrices()[0], bg_rect, cv::Scalar(0, 0, 0), cv::FILLED);
+                    cv::rectangle(GET_CV_MAT(hmat), bg_rect, cv::Scalar(0, 0, 0), cv::FILLED);
                 }
 
-                hmat.draw_text(text, text_position, font_scale, text_col);
+                hmat.draw_text(text, to_h(text_position), font_scale, to_h(text_col));
             }
 
             // Recurse into sub-objects (with landmark/keypoint sprite overrides)
@@ -657,8 +675,8 @@ void draw_stats_overlay(HailoMat &hmat, HailoROIPtr roi,
         font_scale, font_thickness, &baseline);
     cv::Point text_pos(10, 10 + text_size.height);
     cv::Rect bg_rect(8, 8, text_size.width + 4, text_size.height + baseline + 4);
-    cv::rectangle(hmat.get_matrices()[0], bg_rect, cv::Scalar(0, 0, 0), cv::FILLED);
-    hmat.draw_text(text, text_pos, font_scale, cv::Scalar(255, 255, 255));
+    cv::rectangle(GET_CV_MAT(hmat), bg_rect, cv::Scalar(0, 0, 0), cv::FILLED);
+    hmat.draw_text(text, to_h(text_pos), font_scale, to_h(cv::Scalar(255, 255, 255)));
 }
 
 void face_blur(HailoMat &hmat, HailoROIPtr roi)
@@ -674,7 +692,7 @@ void face_blur(HailoMat &hmat, HailoROIPtr roi)
             auto xmax = std::clamp<int>(((detection_bbox.xmax() * roi_bbox.width()) + roi_bbox.xmin()) * hmat.native_width(), 0, hmat.native_width());
             auto ymax = std::clamp<int>(((detection_bbox.ymax() * roi_bbox.height()) + roi_bbox.ymin()) * hmat.native_height(), 0, hmat.native_height());
             auto rect = cv::Rect(cv::Point(xmin, ymin), cv::Point(xmax, ymax));
-            hmat.blur(rect, cv::Size(13, 13));
+            hmat.blur(to_h(rect), to_h(cv::Size(13, 13)));
 
             roi->remove_objects_typed(HAILO_LANDMARKS);
         }
@@ -707,7 +725,7 @@ static bool parse_kv_string(const std::string &label, const std::string &key, st
 
 void draw_hud_overlay(HailoMat &hmat, HailoROIPtr roi)
 {
-    cv::Mat &frame = hmat.get_matrices()[0];
+    cv::Mat &frame = GET_CV_MAT(hmat);
     int w = frame.cols;
     int h = frame.rows;
 

--- a/hailo_apps/postprocess/meson.build
+++ b/hailo_apps/postprocess/meson.build
@@ -129,6 +129,29 @@ if postprocess_dep.found()
         endif
     endif
 
+    # TAPPAS 5.3.0 removed common:: utility functions (get_xtensor, softmax_2D,
+    # vector_normalization, iou_calc, etc.) from libhailo_opencv_utils.so.
+    # The implementations are now shipped as source files alongside the headers.
+    # Build them into a static convenience library for downstream targets.
+    fs = import('fs')
+    common_impl_dir = '/usr/include/hailo/tappas/common'
+    common_tensors_cpp = common_impl_dir / 'tensors.cpp'
+
+    if fs.is_file(common_tensors_cpp)
+        hailo_common_compat_lib = static_library('hailo_common_compat',
+            [common_impl_dir / 'tensors.cpp',
+             common_impl_dir / 'math.cpp',
+             common_impl_dir / 'nms.cpp'],
+            dependencies : postprocess_dep,
+        )
+        hailo_common_compat_dep = declare_dependency(link_with : hailo_common_compat_lib)
+        message('Built hailo_common_compat from TAPPAS source files (5.3.0+ compat)')
+    else
+        # TAPPAS 5.1.x — symbols are in libhailo_opencv_utils.so, no extra lib needed
+        hailo_common_compat_dep = declare_dependency()
+        message('common:: sources not found — symbols in libhailo_opencv_utils.so (5.1.x)')
+    endif
+
     subdir('cpp')
 else
     message('⚠️  No Hailo TAPPAS dependencies found — skipping C++ postprocess build.')

--- a/hailo_apps/postprocess/meson.build
+++ b/hailo_apps/postprocess/meson.build
@@ -75,9 +75,9 @@ if postprocess_dep.found()
         endif
     endif
     
-    # Check if libhailo_opencv_utils.so exists (it may be missing on some systems like RPi)
-    libhailo_opencv_utils_path = '/usr/lib/aarch64-linux-gnu/libhailo_opencv_utils.so'
-    libhailo_opencv_utils_exists = run_command('test', '-f', libhailo_opencv_utils_path, check: false).returncode() == 0
+    # Check if libhailo_opencv_utils.so exists (it may be missing on community installs)
+    cc = meson.get_compiler('c')
+    libhailo_opencv_utils_exists = cc.find_library('hailo_opencv_utils', required: false).found()
     
     if not libhailo_opencv_utils_exists
         message('⚠️  libhailo_opencv_utils.so not found, filtering it out from linker command')

--- a/hailo_apps/postprocess/meson.build
+++ b/hailo_apps/postprocess/meson.build
@@ -147,9 +147,9 @@ if postprocess_dep.found()
         hailo_common_compat_dep = declare_dependency(link_with : hailo_common_compat_lib)
         message('Built hailo_common_compat from TAPPAS source files (5.3.0+ compat)')
     else
-        # TAPPAS 5.1.x — symbols are in libhailo_opencv_utils.so, no extra lib needed
+        # TAPPAS < 5.3.0 — symbols are in libhailo_opencv_utils.so, no extra lib needed
         hailo_common_compat_dep = declare_dependency()
-        message('common:: sources not found — symbols in libhailo_opencv_utils.so (5.1.x)')
+        message('common:: sources not found — symbols in libhailo_opencv_utils.so (< 5.3.0)')
     endif
 
     subdir('cpp')

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -65,6 +65,10 @@ PROJECT_ROOT=$(pwd)
 # This ensures our project's modules are found first.
 export PYTHONPATH="${PROJECT_ROOT}:${PYTHONPATH}"
 
+# Ensure GStreamer discovers the community overlay plugin installed to the
+# repo-owned directory (avoids requiring root to write to system plugin dir).
+export GST_PLUGIN_PATH="/usr/local/hailo/resources/so:${GST_PLUGIN_PATH}"
+
 echo "Project directory added to PYTHONPATH for this session:"
 echo "${PROJECT_ROOT}"
 


### PR DESCRIPTION
C++ postprocess didn't compile against TAPPAS 5.3.0 — now fixed

Nobody noticed because everyone developing locally was on TAPPAS 5.1.0. Rana hit this during PR #186 (LPR integration) when testing on a 5.3.0 machine and fixed the overlay issues inline with that PR.

We've now extracted those fixes into a dedicated branch (feature/fix-overlay-community-install) so PR #186 can stay focused on LPR. The branch fixes three issues:

HailoMat API break — TAPPAS 5.3.0 changed draw_*/blur to take [hailo_point_t](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[hailo_rect_t](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [cv::Point](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[cv::Rect](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and moved get_matrices() to a free function get_cv_matrices(). Fixed with compile-time detection ([__has_include](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) so the same code builds on both 5.1 and 5.3.

Linker failures (7 of 14 targets) — [common::get_xtensor](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [vector_normalization](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [softmax_2D](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), iou_calc etc. were removed from libhailo_opencv_utils.so. TAPPAS now ships the implementations as source files expecting you to compile them yourself. Fixed by building a static compat library from those sources when detected.

overlay_community install permission error — install_dir pointed to the system GStreamer plugin dir (requires root), unlike every other .so that installs to [so](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Fixed the path and added GST_PLUGIN_PATH export in [setup_env.sh](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

All 16 shared libraries now compile cleanly on both TAPPAS 5.1.x and 5.3.0.

TAPPAS 5.2 compatibility: The fix is safe regardless of whether 5.2 behaves like 5.1 or 5.3, because we detect capabilities rather than version numbers. [__has_include("hailomat_internal.hpp")](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) determines which draw API to use, and fs.is_file() on the TAPPAS source files determines whether to build the compat library. No version check that could misclassify anything — it does the right thing based on what's actually installed.