### PR TITLE
Fix missing threading import in camera_utils.py

### DIFF
--- a/hailo_apps/python/core/common/camera_utils.py
+++ b/hailo_apps/python/core/common/camera_utils.py
@@ -1,13 +1,13 @@
 import os
 import signal
 import subprocess
+import threading
 import time
 import platform
 import cv2
 import sys
 from enum import Enum
 from typing import Any, Optional
-import subprocess
 from .defines import UDEV_CMD, CAMERA_RESOLUTION_MAP
 from .hailo_logger import get_logger
 


### PR DESCRIPTION
PiCamera2CaptureAdapter uses threading.Lock() but threading was never imported, causing a NameError when using --input rpi.

Also removed duplicate subprocess import.

Fixes: https://github.com/hailo-ai/hailo-apps/pull/157

Cherry-picked the threading import fix (the only actual bug), but rejected the Qwen3-VL changes because they hardcode Qwen3's image dimensions as the default, breaking Qwen2-VL for all existing users.