### PR TITLE
Remove non-existent --list flag from Piper voice README

### DIFF
--- a/hailo_apps/python/gen_ai_apps/gen_ai_utils/voice_processing/README.md
+++ b/hailo_apps/python/gen_ai_apps/gen_ai_utils/voice_processing/README.md
@@ -101,7 +101,6 @@ Piper supports many voice models in different languages and styles. To use a dif
 
 1. **Browse available voices:**
    - Visit: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_PYTHON.md
-   - Or list voices: `python3 -m piper.download_voices --list`
 
 2. **Download your chosen voice:**
    ```bash


### PR DESCRIPTION
piper.download_voices has no --list option; the command errors out. The GitHub link above already provides voice browsing.

Fixes: https://github.com/hailo-ai/hailo-apps/pull/135