### PR TITLE
Add version support for HailoRT 4.24.0/5.4.0 and TAPPAS 5.3.1/5.4.0 + package rename

### DIFF
--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -321,8 +321,8 @@ Before running hailo-apps, you need to install the Hailo runtime packages. The i
 **Note: Hailo Model Zoo GenAI** Is required only for Hailo-10H & GenAI use cases, like Hailo-Ollama, more details [Hailo Model Zoo GenAI](/hailo_apps/python/gen_ai_apps/hailo_ollama/README.md)
 
 > **Supported versions:**
-> - **Hailo-8 / Hailo-8L:** HailoRT 4.23, TAPPAS Core 5.1.0 & 5.2.0 & 5.3.0
-> - **Hailo-10H:** HailoRT 5.1.1, 5.2.0 & 5.3.0, TAPPAS Core 5.1.0, 5.2.0 & 5.3.0
+> - **Hailo-8 / Hailo-8L:** HailoRT 4.23 & 4.24, TAPPAS Core 5.1.0, 5.2.0, 5.3.0, 5.3.1 & 5.4.0
+> - **Hailo-10H:** HailoRT 5.1.1, 5.2.0, 5.3.0 & 5.4.0, TAPPAS Core 5.1.0, 5.2.0, 5.3.0, 5.3.1 & 5.4.0
 
 ---
 

--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -314,9 +314,9 @@ Before running hailo-apps, you need to install the Hailo runtime packages. The i
 |---------|------|-------------|
 | `hailort-pcie-driver` | .deb | PCIe driver for Hailo devices |
 | `hailort` | .deb | HailoRT runtime library |
-| `hailo-tappas-core` | .deb | TAPPAS Core GStreamer plugins |
+| `hailo-tappas-core` | .deb | TAPPAS Core GStreamer plugins (named `hailo-apps-core` since TAPPAS 5.4) |
 | `hailort` | .whl | HailoRT Python bindings |
-| `hailo_tappas_core_python_binding` | .whl | TAPPAS Core Python bindings |
+| `hailo_tappas_core_python_binding` | .whl | TAPPAS Core Python bindings (named `hailo-apps-core-python-binding` since TAPPAS 5.4) |
 
 **Note: Hailo Model Zoo GenAI** Is required only for Hailo-10H & GenAI use cases, like Hailo-Ollama, more details [Hailo Model Zoo GenAI](/hailo_apps/python/gen_ai_apps/hailo_ollama/README.md)
 
@@ -346,7 +346,7 @@ For x86_64 Ubuntu systems, download all 5 packages from the [Hailo Developer Zon
 ```bash
 sudo dpkg -i hailort-pcie-driver_<version>_all.deb
 sudo dpkg -i hailort_<version>_amd64.deb
-sudo dpkg -i hailo-tappas-core_<version>_amd64.deb
+sudo dpkg -i hailo-tappas-core_<version>_amd64.deb  # or hailo-apps-core for TAPPAS 5.4+
 ```
 
 ### Install Python Wheels (.whl)
@@ -470,7 +470,7 @@ To completely remove all Hailo components from your system:
 sudo dpkg -l | grep hailo
 
 # Remove them (replace with actual package names from above)
-sudo apt purge hailort hailort-pcie-driver hailo-tappas-core
+sudo apt purge hailort hailort-pcie-driver hailo-tappas-core hailo-apps-core
 ```
 
 **2. Remove Python packages:**
@@ -479,7 +479,7 @@ sudo apt purge hailort hailort-pcie-driver hailo-tappas-core
 pip list | grep hailo
 
 # Remove them (add --break-system-packages if required)
-pip uninstall hailort hailo-tappas-core hailo-apps
+pip uninstall hailort hailo-tappas-core hailo-apps-core hailo-apps
 ```
 
 **3. Remove hailo-apps resources directory:**

--- a/hailo_apps/config/config.yaml
+++ b/hailo_apps/config/config.yaml
@@ -11,10 +11,10 @@
 # These values are auto-detected during installation and written to .env file.
 # Set to "auto" for automatic detection, or specify a fixed value.
 
-hailort_version: "auto"       # Options: "auto", "4.23.0", "5.1.1", "5.2.0", "5.3.0"
-tappas_version: "auto"        # Options: "auto", "5.1.0", "5.2.0", "5.3.0"
+hailort_version: "auto"       # Options: "auto", "4.23.0", "4.24.0", "5.1.1", "5.2.0", "5.3.0", "5.4.0"
+tappas_version: "auto"        # Options: "auto", "5.1.0", "5.2.0", "5.3.0", "5.3.1", "5.4.0"
 tappas_postproc_path: "auto"  # Path to TAPPAS postprocess libs (auto from pkg-config)
-model_zoo_version: "auto"     # Options: "auto", "v2.17.0" (H8), "v5.1.0", "v5.2.0" or "v5.3.0" (H10)
+model_zoo_version: "auto"     # Options: "auto", "v2.18.0", "v2.19.0" (H8), "v5.1.0", "v5.2.0", "v5.3.0" or "v5.4.0" (H10)
 host_arch: "auto"             # Options: "auto", "x86", "rpi", "arm"
 hailo_arch: "auto"            # Options: "auto", "hailo8", "hailo8l", "hailo10h"
 multi_processing: "enabled"   # Options: "enabled", "disabled"
@@ -28,13 +28,17 @@ multi_processing: "enabled"   # Options: "enabled", "disabled"
 valid_versions:
   hailort:
     - "4.23.0"
+    - "4.24.0"
     - "5.1.1"
     - "5.2.0"
     - "5.3.0"
+    - "5.4.0"
   tappas:
     - "5.1.0"
     - "5.2.0"
     - "5.3.0"
+    - "5.3.1"
+    - "5.4.0"
   hailo_arch:
     - "hailo8"
     - "hailo8l"
@@ -51,33 +55,35 @@ valid_versions:
 # The installer validates that the detected HailoRT+TAPPAS combo is in this list.
 
 valid_combinations:
-  hailo8: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0"
-  hailo8l: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0"
-  hailo10h: "5.1.1:5.1.0 5.2.0:5.2.0 5.3.0:5.3.0"
+  hailo8: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0 4.24.0:5.3.1 4.24.0:5.4.0"
+  hailo8l: "4.23.0:5.1.0 4.23.0:5.2.0 4.23.0:5.3.0 4.24.0:5.3.1 4.24.0:5.4.0"
+  hailo10h: "5.1.1:5.1.0 5.2.0:5.2.0 5.3.0:5.3.0 5.3.0:5.3.1 5.4.0:5.4.0"
 
 #-------------------------------------------------------------------------------
 # Model Zoo Version Mapping
 #-------------------------------------------------------------------------------
 # Model Zoo version is derived from HailoRT version:
-#   - H8/H8L: Always v2.17.0
-#   - H10: HailoRT 5.1.x -> v5.1.0, HailoRT 5.2.x -> v5.2.0, HailoRT 5.3.x -> v5.3.0
-# Gen-AI Model Zoo version matches HailoRT version (v5.1.1, v5.2.0, or v5.3.0)
+#   - H8/H8L: HailoRT 4.23.x -> v2.18.0, HailoRT 4.24.x -> v2.19.0
+#   - H10: HailoRT 5.1.x -> v5.1.0, HailoRT 5.2.x -> v5.2.0, HailoRT 5.3.x -> v5.3.0, HailoRT 5.4.x -> v5.4.0
+# Gen-AI Model Zoo version matches HailoRT version (v5.1.1, v5.2.0, v5.3.0, or v5.4.0)
 
 # Fallback mapping (used if HailoRT version detection fails)
 model_zoo_mapping:
-  hailo8: "v2.18.0"
-  hailo8l: "v2.18.0"
-  hailo10h: "v5.3.0"
+  hailo8: "v2.19.0"
+  hailo8l: "v2.19.0"
+  hailo10h: "v5.4.0"
 
 # Valid Model Zoo versions by architecture family (for validation)
 valid_model_zoo_versions:
   h8:   # Applies to hailo8 and hailo8l
+    - "v2.19.0"
     - "v2.18.0"
     - "v2.17.0"
   h10:  # Applies to hailo10h
-    - "v5.1.0"
-    - "v5.2.0"
+    - "v5.4.0"
     - "v5.3.0"
+    - "v5.2.0"
+    - "v5.1.0"
 
 #-------------------------------------------------------------------------------
 # Virtual Environment

--- a/hailo_apps/installation/download_resources.py
+++ b/hailo_apps/installation/download_resources.py
@@ -186,8 +186,8 @@ def map_arch_to_s3_path(hailo_arch: str) -> str:
 def get_model_zoo_version_for_arch(hailo_arch: str) -> tuple[str, str]:
     """Get Model Zoo version and download architecture for a given Hailo architecture.
 
-    For H10: Derives from HailoRT version (5.1.x -> v5.1.0, 5.2.x -> v5.2.0)
-    For H8/H8L: Uses the config-defined default (first entry in VALID_H8_MODEL_ZOO_VERSION)
+    For H10: Derives from HailoRT version (5.1.x -> v5.1.0, 5.2.x -> v5.2.0, etc.)
+    For H8/H8L: Derives from HailoRT version (4.24.x -> v2.19.0, 4.23.x -> v2.18.0)
     """
     download_arch = hailo_arch
 
@@ -195,12 +195,13 @@ def get_model_zoo_version_for_arch(hailo_arch: str) -> tuple[str, str]:
     model_zoo_version = os.getenv(MODEL_ZOO_VERSION_KEY)
 
     if model_zoo_version is None:
+        hailort_version = os.getenv(
+            HAILORT_VERSION_KEY,
+            auto_detect_hailort_version()
+        )
+
         # Auto-select default model zoo version based on device architecture
         if hailo_arch == HAILO10H_ARCH:
-            hailort_version = os.getenv(
-                HAILORT_VERSION_KEY,
-                auto_detect_hailort_version()
-            )
             if not hailort_version:
                 raise RuntimeError(
                     "Failed to determine HailoRT version for Hailo-10H. "
@@ -213,8 +214,14 @@ def get_model_zoo_version_for_arch(hailo_arch: str) -> tuple[str, str]:
                 # For newer versions, use the exact HailoRT version
                 model_zoo_version = f"v{hailort_version}"
         else:
-            # H8/H8L: use the first (newest) valid version from the config
-            model_zoo_version = VALID_H8_MODEL_ZOO_VERSION[0]
+            # H8/H8L: Derive from HailoRT version
+            if hailort_version and hailort_version.startswith("4.24"):
+                model_zoo_version = "v2.19.0"
+            elif hailort_version and hailort_version.startswith("4.23"):
+                model_zoo_version = "v2.18.0"
+            else:
+                # Fallback to newest
+                model_zoo_version = VALID_H8_MODEL_ZOO_VERSION[0]
 
     # Validate the version; fall back to the config default if invalid
     if hailo_arch == HAILO10H_ARCH and model_zoo_version not in VALID_H10_MODEL_ZOO_VERSION:

--- a/hailo_apps/postprocess/meson.build
+++ b/hailo_apps/postprocess/meson.build
@@ -7,7 +7,11 @@ project('hailo-apps', 'c', 'cpp',
                             'cpp_args=-Wno-psabi -Wno-class-memaccess -Wno-deprecated-declarations']
        )
 
-postprocess_dep = dependency('hailo-tappas-core', version : '>=3.30.0', required : false)
+postprocess_dep = dependency('hailo-apps-core', version : '>=3.30.0', required : false)
+
+if not postprocess_dep.found()
+    postprocess_dep = dependency('hailo-tappas-core', version : '>=3.30.0', required : false)
+endif
 
 if not postprocess_dep.found()
     postprocess_dep = dependency('hailo_tappas', version : '>=3.30.0', required : false)
@@ -53,15 +57,19 @@ if postprocess_dep.found()
     rapidjson_inc = include_directories(rapidjson_inc_dir, is_system: true)
 
     # Get the version to determine static vs dynamic linking strategy
-    pkg_name = 'hailo-tappas-core'
+    pkg_name = 'hailo-apps-core'
     pkg_version_result = run_command('pkg-config', '--modversion', pkg_name, check: false)
+    if pkg_version_result.returncode() != 0
+        pkg_name = 'hailo-tappas-core'
+        pkg_version_result = run_command('pkg-config', '--modversion', pkg_name, check: false)
+    endif
     if pkg_version_result.returncode() != 0
         pkg_name = 'hailo_tappas'
         pkg_version_result = run_command('pkg-config', '--modversion', pkg_name, check: false)
     endif
     
     tappas_version = pkg_version_result.returncode() == 0 ? pkg_version_result.stdout().strip() : 'unknown'
-    message('Found hailo-tappas-core version: @0@'.format(tappas_version))
+    message('Found TAPPAS core version: @0@'.format(tappas_version))
     
     # Determine if we should use static libraries (5.2.0+) or dynamic (5.1.0 and earlier)
     use_static = false

--- a/hailo_apps/python/core/common/defines.py
+++ b/hailo_apps/python/core/common/defines.py
@@ -102,10 +102,10 @@ DEFAULT_DOTENV_PATH = "/usr/local/hailo/resources/.env"  # your env file lives h
 DEFAULT_LOCAL_RESOURCES_PATH = _get_local_resources_path()  # bundled GIFs, JSON, etc.
 
 # Supported config options (used for validation in config_utils.py)
-VALID_HAILORT_VERSION = [AUTO_DETECT, "4.23.0", "5.1.1", "5.2.0", "5.3.0"]
-VALID_TAPPAS_VERSION = [AUTO_DETECT, "5.1.0", "5.2.0", "5.3.0"]
-VALID_H10_MODEL_ZOO_VERSION = ["v5.1.0", "v5.2.0", "v5.3.0"]  # First element is default
-VALID_H8_MODEL_ZOO_VERSION = ["v2.18.0", "v2.17.0"]
+VALID_HAILORT_VERSION = [AUTO_DETECT, "4.23.0", "4.24.0", "5.1.1", "5.2.0", "5.3.0", "5.4.0"]
+VALID_TAPPAS_VERSION = [AUTO_DETECT, "5.1.0", "5.2.0", "5.3.0", "5.3.1", "5.4.0"]
+VALID_H10_MODEL_ZOO_VERSION = ["v5.4.0", "v5.3.0", "v5.2.0", "v5.1.0"]  # First element is default
+VALID_H8_MODEL_ZOO_VERSION = ["v2.19.0", "v2.18.0", "v2.17.0"]
 VALID_MODEL_ZOO_VERSION = VALID_H10_MODEL_ZOO_VERSION + VALID_H8_MODEL_ZOO_VERSION
 VALID_HOST_ARCH = [AUTO_DETECT, "x86", "rpi", "arm"]
 VALID_HAILO_ARCH = [AUTO_DETECT, HAILO8_ARCH, HAILO8L_ARCH, HAILO10H_ARCH]

--- a/hailo_apps/python/core/common/defines.py
+++ b/hailo_apps/python/core/common/defines.py
@@ -8,9 +8,12 @@ HAILO8L_ARCH = "hailo8l"
 HAILO10H_ARCH = "hailo10h"
 AUTO_DETECT = "auto"
 HAILO_TAPPAS_CORE = "hailo-tappas-core"
+HAILO_APPS_CORE = "hailo-apps-core"  # New name since TAPPAS 5.4
 HAILO_TAPPAS_CORE_PYTHON_NAMES = [
+    "hailo-apps-core-python-binding",  # New name since TAPPAS 5.4
     "hailo-tappas-core-python-binding",
     "tappas-core-python-binding",
+    HAILO_APPS_CORE,
     HAILO_TAPPAS_CORE,
 ]
 HAILORT_PACKAGE_NAME = "hailort"
@@ -144,7 +147,7 @@ RESOURCES_PATH_DEFAULT = RESOURCES_ROOT_PATH_DEFAULT
 VIRTUAL_ENV_NAME_DEFAULT = "venv_hailo_apps"
 
 # Default TAPPAS post-processing directory - set via environment variable during installation
-# The installer runs: pkg-config --variable=tappas_postproc_lib_dir hailo-tappas-core
+# The installer runs: pkg-config --variable=tappas_postproc_lib_dir hailo-apps-core (or hailo-tappas-core)
 # and stores the result in the .env file as TAPPAS_POSTPROC_PATH
 TAPPAS_POSTPROC_PATH_DEFAULT = ""  # Will be populated from environment at runtime
 

--- a/hailo_apps/python/core/common/installation_utils.py
+++ b/hailo_apps/python/core/common/installation_utils.py
@@ -26,6 +26,7 @@ from .defines import (
     HAILO10H_ARCH_CAPS,
     HAILO15H_ARCH_CAPS,
     HAILO_FW_CONTROL_CMD,
+    HAILO_APPS_CORE,
     HAILO_TAPPAS_CORE,
     HAILO_TAPPAS_CORE_PYTHON_NAMES,
     HAILORT_PACKAGE_NAME,
@@ -274,14 +275,16 @@ def auto_detect_hailort_version() -> str:
 
 
 def auto_detect_tappas_installed() -> bool:
-    """Check if hailo-tappas-core is installed.
+    """Check if hailo-apps-core (or hailo-tappas-core) is installed.
 
     Returns:
         bool: True if TAPPAS core is installed, False otherwise
     """
     hailo_logger.debug("Checking if TAPPAS core is installed.")
     if (
-        detect_pkg_installed(HAILO_TAPPAS_CORE)
+        detect_pkg_installed(HAILO_APPS_CORE)
+        or detect_pkg_installed(HAILO_TAPPAS_CORE)
+        or _auto_detect_pkg_config(HAILO_APPS_CORE)
         or _auto_detect_pkg_config(HAILO_TAPPAS_CORE)
         or _auto_detect_pkg_config("hailo-all")
     ):
@@ -320,6 +323,9 @@ def auto_detect_tappas_version() -> str:
         str: Version string or None if not detected
     """
     hailo_logger.debug("Detecting TAPPAS core version")
+    version = _detect_pkg_config_version(HAILO_APPS_CORE)
+    if version:
+        return version
     version = _detect_pkg_config_version(HAILO_TAPPAS_CORE)
     if version:
         return version
@@ -334,12 +340,16 @@ def auto_detect_tappas_postproc_dir() -> str:
         str: Path to the postproc directory or empty string if not found
     """
     hailo_logger.debug("Detecting TAPPAS post-processing directory")
-    try:
-        return _run_command_with_output(
-            ["pkg-config", "--variable=tappas_postproc_lib_dir", HAILO_TAPPAS_CORE]
-        )
-    except Exception as e:
-        hailo_logger.error(f"Could not detect TAPPAS postproc directory: {e}")
-        return ""
+    for pkg_name in (HAILO_APPS_CORE, HAILO_TAPPAS_CORE):
+        try:
+            result = _run_command_with_output(
+                ["pkg-config", "--variable=tappas_postproc_lib_dir", pkg_name]
+            )
+            if result:
+                return result
+        except Exception:
+            continue
+    hailo_logger.error("Could not detect TAPPAS postproc directory")
+    return ""
 
 

--- a/install.sh
+++ b/install.sh
@@ -356,14 +356,24 @@ get_model_zoo_version() {
 
     case "$arch" in
         hailo8|hailo8l)
-            mz_version="v2.18.0"
+            # H8/H8L: Derive from HailoRT version
+            # HailoRT 4.24.x -> Model Zoo v2.19.0
+            # HailoRT 4.23.x (default) -> Model Zoo v2.18.0
+            if [[ "$hailort_ver" == 4.24.* ]]; then
+                mz_version="v2.19.0"
+            else
+                mz_version="v2.18.0"
+            fi
             ;;
         hailo10h)
             # H10: Derive from HailoRT version
+            # HailoRT 5.4.x -> Model Zoo v5.4.0
             # HailoRT 5.3.x -> Model Zoo v5.3.0
             # HailoRT 5.2.x -> Model Zoo v5.2.0
             # HailoRT 5.1.x (default) -> Model Zoo v5.1.0
-            if [[ "$hailort_ver" == 5.3.* ]]; then
+            if [[ "$hailort_ver" == 5.4.* ]]; then
+                mz_version="v5.4.0"
+            elif [[ "$hailort_ver" == 5.3.* ]]; then
                 mz_version="v5.3.0"
             elif [[ "$hailort_ver" == 5.2.* ]]; then
                 mz_version="v5.2.0"
@@ -1031,7 +1041,7 @@ check_prerequisites() {
 # Helper: infer Hailo arch from driver/hailort version string
 infer_arch_from_version() {
     local ver="$1"
-    if [[ "$ver" == 4.22* || "$ver" == 4.23* ]]; then
+    if [[ "$ver" == 4.22* || "$ver" == 4.23* || "$ver" == 4.24* ]]; then
         echo "hailo8"
     elif [[ "$ver" == 5.* ]]; then
         echo "hailo10h"

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -155,11 +155,11 @@ detect_hailo_arch() {
               "$hailort_version" != "-1" && "$hailort_version" != "unknown" ]]; then
             detection_method="version_inference"
             
-            # Check if versions indicate Hailo8 (4.22.x or 4.23.x)
-            if [[ ("$driver_version" == 4.22* || "$driver_version" == 4.23*) && \
-                  ("$hailort_version" == 4.22* || "$hailort_version" == 4.23*) ]]; then
+            # Check if versions indicate Hailo8 (4.22.x, 4.23.x, or 4.24.x)
+            if [[ ("$driver_version" == 4.22* || "$driver_version" == 4.23* || "$driver_version" == 4.24*) && \
+                  ("$hailort_version" == 4.22* || "$hailort_version" == 4.23* || "$hailort_version" == 4.24*) ]]; then
                 arch="hailo8"
-                echo "[INFO] Inferred Hailo architecture: HAILO8 (from driver/hailort version 4.22.x/4.23.x)"
+                echo "[INFO] Inferred Hailo architecture: HAILO8 (from driver/hailort version 4.22.x/4.23.x/4.24.x)"
                 echo "[INFO] Note: This is inferred from package versions. Connect device to confirm via hailortcli."
             # Check if versions indicate Hailo10H (>= 5.0.0)
             elif compare_versions "$driver_version" "5.0.0" && compare_versions "$hailort_version" "5.0.0"; then
@@ -212,7 +212,7 @@ validate_versions_for_arch() {
     if [[ "$packages_installed" == "false" ]]; then
         echo "[INFO] Hailo packages not installed, skipping version validation for $arch"
         echo "[INFO] To validate versions, please install:"
-        echo "[INFO]   - For Hailo8/Hailo8L: driver and hailort version 4.23.x"
+        echo "[INFO]   - For Hailo8/Hailo8L: driver and hailort version 4.23.x or 4.24.x"
         echo "[INFO]   - For Hailo10H: driver and hailort version >= 5.0.0"
         return 0
     fi
@@ -224,11 +224,11 @@ validate_versions_for_arch() {
         # Check driver version
         if [[ "$driver_version" != "-1" && "$driver_version" != "unknown" && -n "$driver_version" ]]; then
             validations_done=$((validations_done + 1))
-            # Check if version starts with 4.23
-            if [[ "$driver_version" == 4.23* ]]; then
-                echo "[OK]   Driver version $driver_version is valid for $arch (4.23.x)"
+            # Check if version starts with 4.23 or 4.24
+            if [[ "$driver_version" == 4.23* || "$driver_version" == 4.24* ]]; then
+                echo "[OK]   Driver version $driver_version is valid for $arch (4.23.x/4.24.x)"
             else
-                echo "[ERROR] Driver version $driver_version is invalid for $arch. Expected 4.23.x"
+                echo "[ERROR] Driver version $driver_version is invalid for $arch. Expected 4.23.x or 4.24.x"
                 errors=$((errors + 1))
             fi
         fi
@@ -236,11 +236,11 @@ validate_versions_for_arch() {
         # Check hailort version
         if [[ "$hailort_version" != "-1" && "$hailort_version" != "unknown" && -n "$hailort_version" ]]; then
             validations_done=$((validations_done + 1))
-            # Check if version starts with 4.23
-            if [[ "$hailort_version" == 4.23* ]]; then
-                echo "[OK]   HailoRT version $hailort_version is valid for $arch (4.23.x)"
+            # Check if version starts with 4.23 or 4.24
+            if [[ "$hailort_version" == 4.23* || "$hailort_version" == 4.24* ]]; then
+                echo "[OK]   HailoRT version $hailort_version is valid for $arch (4.23.x/4.24.x)"
             else
-                echo "[ERROR] HailoRT version $hailort_version is invalid for $arch. Expected 4.23.x"
+                echo "[ERROR] HailoRT version $hailort_version is invalid for $arch. Expected 4.23.x or 4.24.x"
                 errors=$((errors + 1))
             fi
         fi
@@ -618,7 +618,7 @@ to_check() {
 
     if [[ "$hailo_arch" == "hailo8" || "$hailo_arch" == "hailo8l" ]]; then
         for _v in "${_candidates[@]}"; do
-            if [[ "$_v" == 4.23* ]]; then driver_version="$_v"; _driver_matched=true; break; fi
+            if [[ "$_v" == 4.23* || "$_v" == 4.24* ]]; then driver_version="$_v"; _driver_matched=true; break; fi
         done
     elif [[ "$hailo_arch" == "hailo10h" ]]; then
         for _v in "${_candidates[@]}"; do

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -395,8 +395,8 @@ check_tappas_packages() {
     local found=false
 
     # 1) Check for known Debian packages - handle versioned packages
-    if dpkg -l 2>/dev/null | grep -E "^ii.*(hailo-tappas-core|hailo-tappas|tappas-core|tappas)" | head -1 | grep -q .; then
-        pkg_line=$(dpkg -l 2>/dev/null | grep -E "^ii.*(hailo-tappas-core|hailo-tappas|tappas-core|tappas)" | head -1)
+    if dpkg -l 2>/dev/null | grep -E "^ii.*(hailo-apps-core|hailo-tappas-core|hailo-tappas|tappas-core|tappas)" | head -1 | grep -q .; then
+        pkg_line=$(dpkg -l 2>/dev/null | grep -E "^ii.*(hailo-apps-core|hailo-tappas-core|hailo-tappas|tappas-core|tappas)" | head -1)
         pkg_name=$(echo "$pkg_line" | awk '{print $2}')
         version=$(echo "$pkg_line" | awk '{print $3}')
         echo "[OK]   $pkg_name (system) version: $version"
@@ -405,7 +405,7 @@ check_tappas_packages() {
 
     # 2) Fallback to pkg-config if no dpkg package found
     if ! $found; then
-        for pc in hailo-tappas-core hailo_tappas tappas-core tappas; do
+        for pc in hailo-apps-core hailo-tappas-core hailo_tappas tappas-core tappas; do
             if pkg-config --exists "$pc" 2>/dev/null; then
                 if pkg-config --modversion "$pc" &>/dev/null; then
                     version=$(pkg-config --modversion "$pc")
@@ -422,7 +422,7 @@ check_tappas_packages() {
 
     # 3) If still not found
     if ! $found; then
-        echo "[MISSING] any of hailo-tappas-core / hailo-tappas / tappas-core (system), version: -1"
+        echo "[MISSING] any of hailo-apps-core / hailo-tappas-core / hailo-tappas / tappas-core (system), version: -1"
     fi
 
     # 4) Always return a key=value
@@ -501,7 +501,7 @@ check_tappas_core_py() {
     # Check pip-distribution with multiple possible package names
     found_version=""
     found_pkg=""
-    for pkg in "hailo-tappas-core-python-binding" "tappas-core-python-binding" "hailo-tappas-python-binding" "tappas"; do
+    for pkg in "hailo-apps-core-python-binding" "hailo-tappas-core-python-binding" "tappas-core-python-binding" "hailo-tappas-python-binding" "tappas"; do
         if ver=$(detect_pip_pkg_version "$pkg") && [[ -n "$ver" ]]; then
             tappas_python_version="$ver"
             found_version="$ver"

--- a/scripts/uninstall_hailo_packages.sh
+++ b/scripts/uninstall_hailo_packages.sh
@@ -10,15 +10,15 @@ echo "Removing pip packages..."
 # Try removing as regular user (in case installed with --user or --break-system-packages)
 if [ -n "$SUDO_USER" ]; then
     echo "Trying to remove pip packages as user $SUDO_USER..."
-    sudo -u "$SUDO_USER" pip uninstall -y --break-system-packages hailo-tappas-core-python-binding hailort 2>/dev/null || true
+    sudo -u "$SUDO_USER" pip uninstall -y --break-system-packages hailo-apps-core-python-binding hailo-tappas-core-python-binding hailort 2>/dev/null || true
 fi
 # Try removing as root (in case installed system-wide with sudo)
 echo "Trying to remove pip packages as root..."
-pip uninstall -y --break-system-packages hailo-tappas-core-python-binding hailort 2>/dev/null || true
+pip uninstall -y --break-system-packages hailo-apps-core-python-binding hailo-tappas-core-python-binding hailort 2>/dev/null || true
 
 # Uninstall apt packages
 echo "Removing apt packages..."
-sudo apt purge -y hailo-tappas-core hailort hailort-pcie-driver 2>/dev/null || true
+sudo apt purge -y hailo-apps-core hailo-tappas-core hailort hailort-pcie-driver 2>/dev/null || true
 
 # Remove kernel modules
 echo "Removing kernel modules..."


### PR DESCRIPTION
Summary
Adds support for new HailoRT/TAPPAS version combinations and handles the TAPPAS package rename from hailo-tappas-core to hailo-apps-core starting in TAPPAS 5.4.

New Version Combinations
Architecture	HailoRT	TAPPAS	Model Zoo
Hailo-8 / Hailo-8L	4.24.0	5.3.1	v2.19.0
Hailo-8 / Hailo-8L	4.24.0	5.4.0	v2.19.0
Hailo-10H	5.3.0	5.3.1	v5.3.0
Hailo-10H	5.4.0	5.4.0	v5.4.0
TAPPAS Package Rename (5.4+)
Starting with TAPPAS 5.4, the Debian package is renamed from hailo-tappas-core → hailo-apps-core and the Python binding from hailo-tappas-core-python-binding → hailo-apps-core-python-binding. All detection chains now try the new name first with fallback to the old name for backward compatibility.

Changes
Version additions:

config.yaml — new valid versions, combinations, and Model Zoo mappings
defines.py — updated version lists and Model Zoo version arrays
install.sh — Model Zoo derivation for HailoRT 4.24.x (→ v2.19.0) and 5.4.x (→ v5.4.0), arch inference for 4.24
download_resources.py — H8/H8L Model Zoo version derivation from HailoRT version
check_installed_packages.sh — version inference and validation for 4.24.x
Package rename support:

defines.py — HAILO_APPS_CORE constant, updated HAILO_TAPPAS_CORE_PYTHON_NAMES
installation_utils.py — dual-package detection in auto_detect_tappas_installed(), auto_detect_tappas_version(), auto_detect_tappas_postproc_dir()
check_installed_packages.sh — hailo-apps-core in dpkg grep, pkg-config loop, pip detection
uninstall_hailo_packages.sh — uninstall both old and new package names
meson.build — hailo-apps-core as primary fallback in dependency resolution
installation.md — documented the rename
Testing
Backward compatible: systems with hailo-tappas-core (TAPPAS ≤ 5.3.x) continue to work unchanged
Forward compatible: systems with hailo-apps-core (TAPPAS 5.4+) are now detected correctly
Version validation updated for all new HailoRT/TAPPAS pairs