### PR TITLE
fix: remove broken zidane.jpg resource (ultralytics URL returns 308)

### DIFF
--- a/hailo_apps/config/resources_config.yaml
+++ b/hailo_apps/config/resources_config.yaml
@@ -121,19 +121,6 @@ videos:
 # Shared images for all apps
 # Tags use app names only (no _p/_s suffixes)
 images:
-  - name: zidane.jpg
-    url: https://ultralytics.com/images/zidane.jpg
-    tag:
-      - detection
-      - object_detection
-      - object_detection_onnx_postproc
-      - simple_detection
-      - instance_segmentation
-      - onnxrt_hailo_pipeline
-      - pose_estimation
-      - pose_estimation_onnx_postproc
-      - classifier
-      - semantic_segmentation
   - name: dog_bicycle.jpg
     source: s3
     tag:

--- a/hailo_apps/config/test_definition_config.yaml
+++ b/hailo_apps/config/test_definition_config.yaml
@@ -667,7 +667,6 @@ resources:
 
   photos:
     - name: "dog_bicycle.jpg"
-    - name: "zidane.jpg"
     - name: "bus.jpg"
     - name: "input_image.png"
     - name: "ocr_img1.png"

--- a/hailo_apps/cpp/classification/README.md
+++ b/hailo_apps/cpp/classification/README.md
@@ -120,7 +120,7 @@ Example
 
 - For a single image:
     ```shell script
-    ./build/classifier -n resnet_v1_50.hef -i zidane.jpg
+    ./build/classifier -n resnet_v1_50.hef -i dog_bicycle.jpg
     ```
     Output image is saved as processed_image_0.jpg
 

--- a/hailo_apps/cpp/pose_estimation/README.md
+++ b/hailo_apps/cpp/pose_estimation/README.md
@@ -89,7 +89,7 @@ Example
 
 - For a single image:
     ```shell script
-    ./build/pose_estimation -n yolov8m_pose.hef -i zidane.jpg
+    ./build/pose_estimation -n yolov8m_pose.hef -i dog_bicycle.jpg
     ```
     Output image is saved as processed_image_0.jpg
 

--- a/hailo_apps/cpp/semantic_segmentation/README.md
+++ b/hailo_apps/cpp/semantic_segmentation/README.md
@@ -88,7 +88,7 @@ Example
 
 - For a single image:
     ```shell script
-    ./build/semantic_segmentation -n fcn8_resnet_v1_18.hef -i zidane.jpg
+    ./build/semantic_segmentation -n fcn8_resnet_v1_18.hef -i dog_bicycle.jpg
     ```
     Output image is saved as processed_image_0.jpg
 

--- a/hailo_apps/python/standalone_apps/instance_segmentation/README.md
+++ b/hailo_apps/python/standalone_apps/instance_segmentation/README.md
@@ -171,7 +171,7 @@ Example
 
 **Inference on an image**
 ```shell script
-./instance_segmentation.py -n yolov5m_seg_with_nms.hef -i zidane.jpg -m v5
+./instance_segmentation.py -n yolov5m_seg_with_nms.hef -i dog_bicycle.jpg -m v5
 ```
 
 **Inference on a folder of images**

--- a/hailo_apps/python/standalone_apps/pose_estimation/README.md
+++ b/hailo_apps/python/standalone_apps/pose_estimation/README.md
@@ -154,7 +154,7 @@ Example
 
 **Inference on single image**
 ```shell script
-./pose_estimation.py -n yolov8s_pose.hef -i zidane.jpg -b 1
+./pose_estimation.py -n yolov8s_pose.hef -i dog_bicycle.jpg -b 1
 ```
 
 **Inference on a usb camera stream**

--- a/hailo_apps/python/standalone_apps/yolo26/pose_estimation/README.md
+++ b/hailo_apps/python/standalone_apps/yolo26/pose_estimation/README.md
@@ -186,7 +186,7 @@ Example
 
 **Inference on single image**
 ```shell script
-./pose_estimation_onnx_postproc.py -i zidane.jpg -b 1
+./pose_estimation_onnx_postproc.py -i dog_bicycle.jpg -b 1
 ```
 
 **Inference on a usb camera stream**


### PR DESCRIPTION
The external URL https://ultralytics.com/images/zidane.jpg now returns HTTP 308 Permanent Redirect, causing download failures. Remove the resource entry since dog_bicycle.jpg (hosted on our S3) covers all the same app tags and serves as a drop-in replacement.