### PR TITLE
feat(cpp): add CSI camera support for Astrial/IMX8 (-i csi)

### DIFF
--- a/hailo_apps/cpp/README.md
+++ b/hailo_apps/cpp/README.md
@@ -55,6 +55,7 @@ yaml-cpp and libcurl are bundled as submodules and built automatically — no ma
 | CMake | 3.20 | [cmake.org](https://cmake.org/download/) |
 | OpenCV | 4.5.4 | `vcpkg install opencv` |
 | Visual Studio | 2019+ | With "Desktop development with C++" workload |
+| Git for Windows | any | [git-scm.com](https://git-scm.com/download/win) — required by `build.ps1` for Unix tools (`sed`) |
 
 ---
 
@@ -87,18 +88,16 @@ cd hailo_apps/cpp
 
 ## Building the Applications
 
-All applications are built through a single entry point: **`build.sh`** (Linux) or per-app CMake commands (Windows).
+All applications are built through a single build script: **`build.sh`** on Linux and **`build.ps1`** on Windows. Both scripts share the same interface and behavior:
 
-### Linux — `build.sh`
-
-`build.sh` is the recommended way to build on Linux. It handles everything in order:
-
-1. Checks whether yaml-cpp and libcurl are available as system packages.  
-2. If not found on the system, builds them **once** from the bundled submodules into a shared `deps/` directory.  
-3. Builds whichever applications you specify (or all of them).  
-4. Prints a clean pass/fail summary at the end.
+1. Check whether yaml-cpp and libcurl are available as system packages.
+2. If not, build them **once** from the bundled submodules into a shared `deps/` directory.
+3. Build whichever applications you specify (or all of them).
+4. Print a pass/fail summary at the end.
 
 Shared dependencies are built only once and reused across all applications — subsequent builds are fast.
+
+Use `build.sh` on Linux and `build.ps1` on Windows — the interface is identical.
 
 #### Build All Applications
 
@@ -108,8 +107,6 @@ Shared dependencies are built only once and reused across all applications — s
 
 #### Build Specific Applications
 
-Pass one or more application names as arguments:
-
 ```bash
 ./build.sh object_detection
 ./build.sh object_detection instance_segmentation pose_estimation
@@ -117,12 +114,11 @@ Pass one or more application names as arguments:
 
 #### Clean Build (Remove Previous Build Artifacts)
 
-Use `--rebuild` to delete each application's `build/` directory before rebuilding. This is useful when switching branches or after changing CMake options:
+Use `--rebuild` to delete each application's `build/` directory before rebuilding. Useful when switching branches or after changing CMake options:
 
 ```bash
 ./build.sh --rebuild
 ./build.sh --rebuild object_detection
-./build.sh --rebuild object_detection instance_segmentation
 ```
 
 #### Help
@@ -168,16 +164,6 @@ At the end of each build, a summary shows which applications succeeded and which
 ==========================================
 ```
 
-### Windows — Per-Application CMake
-
-On Windows, build each application individually from its directory:
-
-```bat
-cd hailo_apps\cpp\object_detection
-cmake -S. -Bbuild -DCMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS=True
-cmake --build build --config Release
-```
-
 ---
 
 ## Application Reference
@@ -220,6 +206,7 @@ To quickly see what a binary accepts, run it with `--help`:
 | USB camera | `--input usb` | Auto-selects first USB camera |
 | Specific camera | `--input /dev/video2` | Linux only |
 | Raspberry Pi camera | `--input rpi` | Raspberry Pi only |
+| CSI camera | `--input csi` | Yocto-based systems (e.g. Astrial/IMX8). ISP must be initialized first — see [Platform Notes](#platform-notes) |
 | Camera index | `--input 1` | Windows camera index |
 | Predefined resource | `--input bus` | Auto-downloaded from `resources_config.yaml` |
 
@@ -264,6 +251,14 @@ Models in the same group share the device's virtual device context, improving re
   ```
 
 - **Video saving (`-s`):** When saving a processed video stream (`-s`/`--save-stream-output`), FPS may drop when decoding from a video file due to VPU contention between the hardware decoder and encoder. This does not affect camera input.
+
+- **CSI camera (`--input csi`):** The Astrial exposes its CSI camera as a standard V4L2 device after the ISP is initialized. Before using `--input csi`, start the ISP on the device:
+
+  ```bash
+  cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &
+  ```
+
+  The application will then auto-detect the first non-USB V4L2 capture device. If no device is found, a warning is printed with this command as a reminder. `--input csi` is only accepted on Yocto-based systems — it will error immediately on Windows or standard desktop Linux.
 
 ---
 

--- a/hailo_apps/cpp/classification/README.md
+++ b/hailo_apps/cpp/classification/README.md
@@ -87,6 +87,7 @@ Arguments
     - On Linux, you can also use /dev/vidoeX (e.g., `/dev/video0`) to select a specific camera.
     - On Windows, you can also use a camera index (`0`, `1`, `2`, ...) to select a specific camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `resources_config.yaml` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
     - Use `--list-inputs` to display all available predefined inputs.

--- a/hailo_apps/cpp/common/resources_manager.cpp
+++ b/hailo_apps/cpp/common/resources_manager.cpp
@@ -847,7 +847,7 @@ std::string ResourcesManager::resolve_input_arg(const std::string &app,
     //  - "usb" / "rpi"
     //  - Windows: "0", "1", ...
     //  - Linux: "/dev/videoX"
-    if (input_arg == "usb" || input_arg == "rpi" ||
+    if (input_arg == "usb" || input_arg == "rpi" || input_arg == "csi" ||
         (!input_arg.empty() && std::all_of(input_arg.begin(), input_arg.end(), ::isdigit)) ||
         (input_arg.rfind("/dev/video", 0) == 0))
     {

--- a/hailo_apps/cpp/common/toolbox.cpp
+++ b/hailo_apps/cpp/common/toolbox.cpp
@@ -139,6 +139,15 @@ void validate_visualization_params(const VisualizationParams &vis, AppVisMode mo
     }
 }
 
+static std::string make_csi_gst_pipeline(const std::string &device, int w, int h)
+{
+    return "v4l2src device=" + device + " ! "
+           "videoscale ! videoconvert ! "
+           "video/x-raw,format=BGR,width=" + std::to_string(w) +
+           ",height=" + std::to_string(h) + " ! "
+           "appsink max-buffers=1 drop=true sync=false";
+}
+
 static std::string make_rpi_gst_pipeline(int w, int h, int fps)
 {
     return "libcamerasrc ! "
@@ -167,6 +176,41 @@ static bool is_raspberry_pi()
     std::getline(f, model);
 
     return model.find(RPI_POSSIBLE_NAME) != std::string::npos;
+#endif
+}
+
+static bool is_yocto()
+{
+#ifdef _WIN32
+    return false;
+#else
+    // Known identifiers for Yocto/OpenEmbedded-based distros.
+    // Checked case-insensitively against the ID, ID_LIKE, and CPE_NAME fields.
+    static const std::vector<std::string> YOCTO_MARKERS = {
+        "poky", "yocto", "openembedded", "fsl-imx", "buildroot", "openwrt"
+    };
+
+    std::ifstream f("/etc/os-release");
+    if (!f.is_open()) return false;
+
+    std::string line;
+    while (std::getline(f, line)) {
+        // Only inspect relevant keys
+        const bool relevant =
+            line.rfind("ID=", 0)       == 0 ||
+            line.rfind("ID_LIKE=", 0)  == 0 ||
+            line.rfind("CPE_NAME=", 0) == 0;
+        if (!relevant) continue;
+
+        std::string lower = line;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+
+        for (const auto &marker : YOCTO_MARKERS) {
+            if (lower.find(marker) != std::string::npos)
+                return true;
+        }
+    }
+    return false;
 #endif
 }
 
@@ -471,6 +515,38 @@ static std::vector<CameraDevice> get_usb_video_devices_linux()
 
     return usb_video_devices;
 }
+
+static std::string find_csi_video_device_linux()
+{
+    std::vector<std::string> candidates;
+    for (const auto &entry : fs::directory_iterator("/dev")) {
+        const std::string name = entry.path().filename().string();
+        if (name.rfind("video", 0) == 0)
+            candidates.push_back("/dev/" + name);
+    }
+    std::sort(candidates.begin(), candidates.end());
+
+    for (const auto &device : candidates) {
+        const std::string info = run_command(
+            "udevadm info --query=all --name=" + device + " 2>/dev/null");
+
+        if (info.find("ID_BUS=usb") != std::string::npos)
+            continue;
+
+        // Check capture capability: prefer udev property, fall back to v4l2-ctl
+        if (info.find("ID_V4L_CAPABILITIES") != std::string::npos) {
+            if (info.find(":capture:") == std::string::npos) continue;
+        } else {
+            const std::string cap = run_command(
+                "v4l2-ctl --device=" + device + " --info 2>/dev/null");
+            if (cap.find("Video Capture") == std::string::npos) continue;
+        }
+
+        std::cout << "CSI camera detected: " << device << "\n";
+        return device;
+    }
+    return "";
+}
 #endif
 
 #ifdef _WIN32
@@ -603,6 +679,29 @@ InputType determine_input_type(const std::string& input_path,
         capture = open_video_capture(input_path, capture, org_height, org_width, frame_count,
                                      true /*is_camera*/, camera_resolution);
 
+    //5. CSI camera shortcut (Astrial/IMX8 and other platform CSI cameras)
+    } else if (input_path == "csi") {
+#ifdef _WIN32
+        throw std::runtime_error("'csi' camera input is not supported on Windows.");
+#else
+        if (!is_yocto()) {
+            throw std::runtime_error(
+                "'csi' camera input is only supported on Yocto-based embedded systems (e.g. Astrial/IMX8).\n"
+                "Use '-i usb' for a USB camera or '-i rpi' on Raspberry Pi.");
+        }
+        const std::string csi_device = find_csi_video_device_linux();
+        if (csi_device.empty()) {
+            std::cerr << "-W- No CSI camera detected.\n"
+                      << "-W- On Astrial/IMX8, initialize the ISP first:\n"
+                      << "-W-   cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &\n";
+            throw std::runtime_error("No CSI camera detected");
+        }
+        input_type.is_camera = true;
+        std::cout << "Using CSI camera: " << csi_device << "\n";
+        capture = open_video_capture("csi:" + csi_device, capture, org_height, org_width,
+                                     frame_count, true /*is_camera*/, camera_resolution);
+#endif
+
     } else {
         throw std::runtime_error("Unsupported input type: " + input_path);
     }
@@ -708,12 +807,13 @@ cv::VideoCapture open_video_capture(const std::string &input_path,
     const std::string &camera_resolution)
     {
     const bool is_rpi_input = (input_path == "rpi");
+    const bool is_csi       = (input_path.rfind("csi:", 0) == 0);
+    const std::string device = is_csi ? input_path.substr(4) : input_path;
     // Validate platform
     if (is_rpi_input && !is_raspberry_pi()) {
         throw std::runtime_error(
             "You requested '-i rpi', but this system is not a Raspberry Pi.\n"
-            "Use '-i usb' or a video file instead."
-        );
+            "Use '-i usb' or a video file instead.");
     }
 
     // Default camera resolution
@@ -744,6 +844,9 @@ cv::VideoCapture open_video_capture(const std::string &input_path,
         org_width  = width  = 800;
         org_height = height = 600;
         std::string pipeline = make_rpi_gst_pipeline(width, height, fps);
+        capture.open(pipeline, cv::CAP_GSTREAMER);
+    } else if (is_csi) {
+        std::string pipeline = make_csi_gst_pipeline(device, width, height);
         capture.open(pipeline, cv::CAP_GSTREAMER);
     } else {
     #ifdef _WIN32

--- a/hailo_apps/cpp/depth_estimation_mono/README.md
+++ b/hailo_apps/cpp/depth_estimation_mono/README.md
@@ -61,6 +61,7 @@ Arguments
 - `-i, --input`:
   - An **input source** such as an image (`bus.jpg`), a video (`video.mp4`), a directory of images, or `usb` to use the system camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `inputs.json` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
 - `-b, --batch-size`: [optional] Number of images in one batch. Defaults to 1.

--- a/hailo_apps/cpp/instance_segmentation/README.md
+++ b/hailo_apps/cpp/instance_segmentation/README.md
@@ -78,6 +78,7 @@ Arguments
 - `-i, --input`:
   - An **input source** such as an image (`bus.jpg`), a video (`video.mp4`), a directory of images, or `usb` to use the system camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `inputs.json` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
 - `-b, --batch-size`: [optional] Number of images in one batch. Defaults to 1.

--- a/hailo_apps/cpp/object_detection/README.md
+++ b/hailo_apps/cpp/object_detection/README.md
@@ -91,6 +91,7 @@ Arguments
     - On Linux, you can also use /dev/vidoeX (e.g., `/dev/video0`) to select a specific camera.
     - On Windows, you can also use a camera index (`0`, `1`, `2`, ...) to select a specific camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `resources_config.yaml` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
     - Use `--list-inputs` to display all available predefined inputs.

--- a/hailo_apps/cpp/onnxrt_hailo_pipeline/README.md
+++ b/hailo_apps/cpp/onnxrt_hailo_pipeline/README.md
@@ -120,6 +120,7 @@ Arguments
     - On Linux, you can also use /dev/vidoeX (e.g., `/dev/video0`) to select a specific camera.
     - On Windows, you can also use a camera index (`0`, `1`, `2`, ...) to select a specific camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `resources_config.yaml` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
     - Use `--list-inputs` to display all available predefined inputs.

--- a/hailo_apps/cpp/oriented_object_detection/README.md
+++ b/hailo_apps/cpp/oriented_object_detection/README.md
@@ -66,6 +66,7 @@ Arguments
 - `-i, --input`:
   - An **input source** such as an image (`bus.jpg`), a video (`video.mp4`), a directory of images, or `usb` to use the system camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `inputs.json` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
 - ``-b, --batch_size (optional)``: Number of images in one batch. Defaults to 1.

--- a/hailo_apps/cpp/pose_estimation/README.md
+++ b/hailo_apps/cpp/pose_estimation/README.md
@@ -59,6 +59,7 @@ Arguments
 - `-i, --input`:
   - An **input source** such as an image (`bus.jpg`), a video (`video.mp4`), a directory of images, or `usb` to use the system camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `inputs.json` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
 - `-b, --batch-size`: [optional] Number of images in one batch. Defaults to 1.

--- a/hailo_apps/cpp/semantic_segmentation/README.md
+++ b/hailo_apps/cpp/semantic_segmentation/README.md
@@ -59,6 +59,7 @@ Arguments
 - `-i, --input`:
   - An **input source** such as an image (`bus.jpg`), a video (`video.mp4`), a directory of images, or `usb` to use the system camera.
     - On Raspberry Pi, you can also use `rpi` to enable the Raspberry Pi camera.
+    - On Astrial/IMX8 (Yocto-based systems), use `csi` to auto-detect and open the CSI camera. The ISP must be initialized first: `cd /opt/imx8-isp/bin && ./run.sh -lm -c dual_imx219_1080p60 &`
   - A **predefined input name** from `inputs.json` (e.g., `bus`, `street`).
     - If you choose a predefined name, the input will be **automatically downloaded** if it doesn't already exist.
 - `-b, --batch-size`: [optional] Number of images in one batch. Defaults to 1.


### PR DESCRIPTION
- Auto-detects first non-USB V4L2 capture device on Yocto systems
- Opens CSI camera via GStreamer v4l2src + videoscale + videoconvert pipeline
- Guards: errors on Windows and non-Yocto Linux (desktop machines)
- Warns with ISP init command if no CSI device found
- Adds is_yocto() detection via /etc/os-release (fsl-imx, openembedded, poky)
- Passes 'csi' as pass-through in ResourcesManager (same as 'usb'/'rpi')
- Updates all cpp READMEs and main README with -i csi documentation