### PR TITLE
fix: add h10-hailort-pcie-driver to driver detection logic

### DIFF
--- a/hailo_apps/python/core/common/defines.py
+++ b/hailo_apps/python/core/common/defines.py
@@ -18,8 +18,6 @@ HAILO_TAPPAS_CORE_PYTHON_NAMES = [
 ]
 HAILORT_PACKAGE_NAME = "hailort"
 HAILORT_PACKAGE_NAME_RPI = "h10-hailort"
-HAILORT_PCIE_DRIVER_PACKAGE_NAME = "hailort-pcie-driver"
-HAILORT_PCIE_DRIVER_PACKAGE_NAME_H10 = "h10-hailort-pcie-driver"
 HAILO_FILE_EXTENSION = ".hef"
 MODEL_ZOO_URL = "https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled"
 S3_RESOURCES_BASE_URL = "https://hailo-csdata.s3.eu-west-2.amazonaws.com/resources"

--- a/hailo_apps/python/core/common/defines.py
+++ b/hailo_apps/python/core/common/defines.py
@@ -18,6 +18,8 @@ HAILO_TAPPAS_CORE_PYTHON_NAMES = [
 ]
 HAILORT_PACKAGE_NAME = "hailort"
 HAILORT_PACKAGE_NAME_RPI = "h10-hailort"
+HAILORT_PCIE_DRIVER_PACKAGE_NAME = "hailort-pcie-driver"
+HAILORT_PCIE_DRIVER_PACKAGE_NAME_H10 = "h10-hailort-pcie-driver"
 HAILO_FILE_EXTENSION = ".hef"
 MODEL_ZOO_URL = "https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled"
 S3_RESOURCES_BASE_URL = "https://hailo-csdata.s3.eu-west-2.amazonaws.com/resources"

--- a/hailo_apps/python/core/common/installation_utils.py
+++ b/hailo_apps/python/core/common/installation_utils.py
@@ -226,7 +226,7 @@ def get_hailort_package_name() -> str:
 
     if host_arch == RPI_NAME_I:
         if detect_hailo_arch() == HAILO10H_ARCH:
-            # Old hailort version used h10-hailort
+            # RPi + Hailo-10H uses h10-hailort (dedicated package)
             if detect_system_pkg_version(HAILORT_PACKAGE_NAME_RPI):
                 hailo_logger.debug(
                     f"Using RPI-specific HailoRT package: {HAILORT_PACKAGE_NAME_RPI}"

--- a/install.sh
+++ b/install.sh
@@ -1042,11 +1042,14 @@ check_prerequisites() {
     esac
 
     # Show HailoRT status and check version match against the matching driver
+    # Check all driver sources: USB, h10-hailort-pcie-driver, hailort-pcie-driver
     local matched_driver_type="" matched_driver_ver="-1"
     if [[ "$usb_driver_version" != "-1" && "$hailort_version" == "$usb_driver_version" ]]; then
         matched_driver_type="USB"; matched_driver_ver="$usb_driver_version"
-    elif [[ "$pcie_driver_version" != "-1" && "$hailort_version" == "$pcie_driver_version" ]]; then
-        matched_driver_type="PCIe"; matched_driver_ver="$pcie_driver_version"
+    elif [[ "$h10_pcie_driver_version" != "-1" && "$hailort_version" == "$h10_pcie_driver_version" ]]; then
+        matched_driver_type="PCIe (H10)"; matched_driver_ver="$h10_pcie_driver_version"
+    elif [[ "$std_pcie_driver_version" != "-1" && "$hailort_version" == "$std_pcie_driver_version" ]]; then
+        matched_driver_type="PCIe"; matched_driver_ver="$std_pcie_driver_version"
     fi
 
     if [[ "$hailort_version" != "-1" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -783,6 +783,10 @@ check_prerequisites() {
     fi
 
     # --- Get installed driver versions from dpkg (always available) ---
+    # H10 and H8 PCIe drivers can coexist on the same host (different package names).
+    # Track both independently; downstream logic selects based on detected architecture.
+    local h10_pcie_driver_version="-1"
+    local h8_pcie_driver_version="-1"
     local pcie_driver_version="-1"
     local usb_driver_version="-1"
     local hailort_version="-1"
@@ -791,13 +795,17 @@ check_prerequisites() {
     local tappas_python_version="-1"
 
     local _v
-    # Check for PCIe driver: try h10-hailort-pcie-driver first (RPi + H10 all 5.x, x86 + H10 from 5.4)
+    # Check for H10 PCIe driver (RPi + H10 all 5.x, x86 + H10 from 5.4)
     _v=$(dpkg-query -W -f='${Status} ${Version}' h10-hailort-pcie-driver 2>/dev/null) || true
-    [[ "$_v" == install\ ok\ installed\ * ]] && pcie_driver_version="${_v##* }"
-    # Fall back to hailort-pcie-driver (x86, or older H10 on x86)
-    if [[ "$pcie_driver_version" == "-1" ]]; then
-        _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-pcie-driver 2>/dev/null) || true
-        [[ "$_v" == install\ ok\ installed\ * ]] && pcie_driver_version="${_v##* }"
+    [[ "$_v" == install\ ok\ installed\ * ]] && h10_pcie_driver_version="${_v##* }"
+    # Check for H8/H8L PCIe driver
+    _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-pcie-driver 2>/dev/null) || true
+    [[ "$_v" == install\ ok\ installed\ * ]] && h8_pcie_driver_version="${_v##* }"
+    # Set combined pcie_driver_version (prefer H10 if present, used for general "is any driver installed?" checks)
+    if [[ "$h10_pcie_driver_version" != "-1" ]]; then
+        pcie_driver_version="$h10_pcie_driver_version"
+    elif [[ "$h8_pcie_driver_version" != "-1" ]]; then
+        pcie_driver_version="$h8_pcie_driver_version"
     fi
 
     _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-usb-driver 2>/dev/null) || true
@@ -861,12 +869,12 @@ check_prerequisites() {
         if [[ "$HAILO_ARCH" == "hailo10h" ]]; then
             if [[ "$usb_driver_version" != "-1" ]]; then
                 driver_type="USB"; driver_version="$usb_driver_version"
-            elif [[ "$pcie_driver_version" != "-1" ]]; then
-                driver_type="PCIe"; driver_version="$pcie_driver_version"
+            elif [[ "$h10_pcie_driver_version" != "-1" ]]; then
+                driver_type="PCIe"; driver_version="$h10_pcie_driver_version"
             fi
         else
-            if [[ "$pcie_driver_version" != "-1" ]]; then
-                driver_type="PCIe"; driver_version="$pcie_driver_version"
+            if [[ "$h8_pcie_driver_version" != "-1" ]]; then
+                driver_type="PCIe"; driver_version="$h8_pcie_driver_version"
             elif [[ "$usb_driver_version" != "-1" ]]; then
                 driver_type="USB"; driver_version="$usb_driver_version"
             fi
@@ -991,7 +999,12 @@ check_prerequisites() {
     local inferred_arch="" inferred_device_name=""
 
     # Show driver status and infer arch
-    if [[ "$pcie_driver_version" != "-1" && "$usb_driver_version" != "-1" ]]; then
+    # Report both H10 and H8 drivers when coexisting
+    if [[ "$h10_pcie_driver_version" != "-1" && "$h8_pcie_driver_version" != "-1" ]]; then
+        log_info "Driver: H10 PCIe ${h10_pcie_driver_version}, H8 PCIe ${h8_pcie_driver_version}"
+        any_driver_installed=true
+        inferred_arch=$(infer_arch_from_version "$h10_pcie_driver_version")
+    elif [[ "$pcie_driver_version" != "-1" && "$usb_driver_version" != "-1" ]]; then
         log_info "Driver: PCIe ${pcie_driver_version}, USB ${usb_driver_version}"
         any_driver_installed=true
         if [[ "$usb_driver_version" == "$hailort_version" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1067,7 +1067,7 @@ check_prerequisites() {
     # Final error message — include connection type if known
     local connection_type=""
     [[ "$matched_driver_type" == "USB" ]] && connection_type=" USB"
-    [[ "$matched_driver_type" == "PCIe" ]] && connection_type=" PCIe"
+    [[ "$matched_driver_type" == PCIe* ]] && connection_type=" PCIe"
 
     if [[ -n "$inferred_device_name" ]]; then
         log_error "No ${inferred_device_name}${connection_type} device detected — reconnect device or reboot and retry"

--- a/install.sh
+++ b/install.sh
@@ -791,16 +791,29 @@ check_prerequisites() {
     local tappas_python_version="-1"
 
     local _v
-    _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-pcie-driver 2>/dev/null) || true
+    # Check for PCIe driver: try h10-hailort-pcie-driver first (RPi + H10 all 5.x, x86 + H10 from 5.4)
+    _v=$(dpkg-query -W -f='${Status} ${Version}' h10-hailort-pcie-driver 2>/dev/null) || true
     [[ "$_v" == install\ ok\ installed\ * ]] && pcie_driver_version="${_v##* }"
+    # Fall back to hailort-pcie-driver (x86, or older H10 on x86)
+    if [[ "$pcie_driver_version" == "-1" ]]; then
+        _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-pcie-driver 2>/dev/null) || true
+        [[ "$_v" == install\ ok\ installed\ * ]] && pcie_driver_version="${_v##* }"
+    fi
 
     _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-usb-driver 2>/dev/null) || true
     [[ "$_v" == install\ ok\ installed\ * ]] && usb_driver_version="${_v##* }"
 
-    _v=$(dpkg-query -W -f='${Status} ${Version}' hailort 2>/dev/null) || true
+    # Check for HailoRT runtime: try h10-hailort first (RPi + H10), then hailort
+    _v=$(dpkg-query -W -f='${Status} ${Version}' h10-hailort 2>/dev/null) || true
     if [[ "$_v" == install\ ok\ installed\ * ]]; then
         hailort_version="${_v##* }"
         HAILORT_VERSION="$hailort_version"
+    else
+        _v=$(dpkg-query -W -f='${Status} ${Version}' hailort 2>/dev/null) || true
+        if [[ "$_v" == install\ ok\ installed\ * ]]; then
+            hailort_version="${_v##* }"
+            HAILORT_VERSION="$hailort_version"
+        fi
     fi
 
     # --- Check 1: hailortcli scan — is any Hailo device physically present? ---

--- a/install.sh
+++ b/install.sh
@@ -784,10 +784,12 @@ check_prerequisites() {
 
     # --- Get installed driver versions from dpkg (always available) ---
     # H10 and H8 PCIe drivers can coexist on the same host (different package names).
-    # Track both independently; downstream logic selects based on detected architecture.
-    local h10_pcie_driver_version="-1"
-    local h8_pcie_driver_version="-1"
-    local pcie_driver_version="-1"
+    # - h10-hailort-pcie-driver: always H10 (RPi all 5.x, x86 from 5.4)
+    # - hailort-pcie-driver: H8/H8L (4.x) OR older H10 on x86 (5.1-5.3)
+    # Use infer_arch_from_version() on the version to determine actual device.
+    local h10_pcie_driver_version="-1"  # from package: h10-hailort-pcie-driver
+    local std_pcie_driver_version="-1"  # from package: hailort-pcie-driver (H8 or old H10)
+    local pcie_driver_version="-1"      # combined: any PCIe driver present
     local usb_driver_version="-1"
     local hailort_version="-1"
     local pyhailort_version="-1"
@@ -795,17 +797,17 @@ check_prerequisites() {
     local tappas_python_version="-1"
 
     local _v
-    # Check for H10 PCIe driver (RPi + H10 all 5.x, x86 + H10 from 5.4)
+    # Check for h10-hailort-pcie-driver (always H10)
     _v=$(dpkg-query -W -f='${Status} ${Version}' h10-hailort-pcie-driver 2>/dev/null) || true
     [[ "$_v" == install\ ok\ installed\ * ]] && h10_pcie_driver_version="${_v##* }"
-    # Check for H8/H8L PCIe driver
+    # Check for hailort-pcie-driver (H8/H8L with 4.x, or older H10 on x86 with 5.1-5.3)
     _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-pcie-driver 2>/dev/null) || true
-    [[ "$_v" == install\ ok\ installed\ * ]] && h8_pcie_driver_version="${_v##* }"
-    # Set combined pcie_driver_version (prefer H10 if present, used for general "is any driver installed?" checks)
+    [[ "$_v" == install\ ok\ installed\ * ]] && std_pcie_driver_version="${_v##* }"
+    # Set combined pcie_driver_version for general "is any PCIe driver installed?" checks
     if [[ "$h10_pcie_driver_version" != "-1" ]]; then
         pcie_driver_version="$h10_pcie_driver_version"
-    elif [[ "$h8_pcie_driver_version" != "-1" ]]; then
-        pcie_driver_version="$h8_pcie_driver_version"
+    elif [[ "$std_pcie_driver_version" != "-1" ]]; then
+        pcie_driver_version="$std_pcie_driver_version"
     fi
 
     _v=$(dpkg-query -W -f='${Status} ${Version}' hailort-usb-driver 2>/dev/null) || true
@@ -871,10 +873,13 @@ check_prerequisites() {
                 driver_type="USB"; driver_version="$usb_driver_version"
             elif [[ "$h10_pcie_driver_version" != "-1" ]]; then
                 driver_type="PCIe"; driver_version="$h10_pcie_driver_version"
+            elif [[ "$std_pcie_driver_version" != "-1" && "$std_pcie_driver_version" == 5.* ]]; then
+                # Old H10 on x86 (5.1-5.3) uses hailort-pcie-driver
+                driver_type="PCIe"; driver_version="$std_pcie_driver_version"
             fi
         else
-            if [[ "$h8_pcie_driver_version" != "-1" ]]; then
-                driver_type="PCIe"; driver_version="$h8_pcie_driver_version"
+            if [[ "$std_pcie_driver_version" != "-1" && "$std_pcie_driver_version" == 4.* ]]; then
+                driver_type="PCIe"; driver_version="$std_pcie_driver_version"
             elif [[ "$usb_driver_version" != "-1" ]]; then
                 driver_type="USB"; driver_version="$usb_driver_version"
             fi
@@ -999,11 +1004,16 @@ check_prerequisites() {
     local inferred_arch="" inferred_device_name=""
 
     # Show driver status and infer arch
-    # Report both H10 and H8 drivers when coexisting
-    if [[ "$h10_pcie_driver_version" != "-1" && "$h8_pcie_driver_version" != "-1" ]]; then
-        log_info "Driver: H10 PCIe ${h10_pcie_driver_version}, H8 PCIe ${h8_pcie_driver_version}"
+    # Report both drivers when coexisting; use version to infer actual arch
+    if [[ "$h10_pcie_driver_version" != "-1" && "$std_pcie_driver_version" != "-1" ]]; then
+        log_info "Driver: h10-hailort-pcie-driver ${h10_pcie_driver_version}, hailort-pcie-driver ${std_pcie_driver_version}"
         any_driver_installed=true
-        inferred_arch=$(infer_arch_from_version "$h10_pcie_driver_version")
+        # Both present: infer from HailoRT version (which device the user intends to use)
+        if [[ "$hailort_version" != "-1" ]]; then
+            inferred_arch=$(infer_arch_from_version "$hailort_version")
+        else
+            inferred_arch=$(infer_arch_from_version "$h10_pcie_driver_version")
+        fi
     elif [[ "$pcie_driver_version" != "-1" && "$usb_driver_version" != "-1" ]]; then
         log_info "Driver: PCIe ${pcie_driver_version}, USB ${usb_driver_version}"
         any_driver_installed=true

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -341,21 +341,23 @@ check_kernel_module() {
         fi
     else
         # Fallback check for the package if neither module is found
-        # Both H10 and H8 drivers can coexist — check both independently
+        # Both drivers can coexist — check both independently
+        # h10-hailort-pcie-driver: always H10 (RPi all 5.x, x86 from 5.4)
+        # hailort-pcie-driver: H8/H8L (4.x) or older H10 on x86 (5.1-5.3)
         local h10_version="-1"
-        local h8_version="-1"
+        local std_version="-1"
         if dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep -q "^ii"; then
             h10_version=$(dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
             echo "[OK]   h10-hailort-pcie-driver package installed, version: $h10_version"
         fi
         if dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep -q "^ii"; then
-            h8_version=$(dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
-            echo "[OK]   hailort-pcie-driver package installed, version: $h8_version"
+            std_version=$(dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
+            echo "[OK]   hailort-pcie-driver package installed, version: $std_version"
         fi
         if [[ "$h10_version" != "-1" ]]; then
             version="$h10_version"
-        elif [[ "$h8_version" != "-1" ]]; then
-            version="$h8_version"
+        elif [[ "$std_version" != "-1" ]]; then
+            version="$std_version"
         else
             echo "[WARN] hailo_pci/hailo1x_pci module not found, version: -1"
         fi

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -341,13 +341,21 @@ check_kernel_module() {
         fi
     else
         # Fallback check for the package if neither module is found
-        # Check h10-hailort-pcie-driver first (RPi + H10 all 5.x, x86 + H10 from 5.4)
+        # Both H10 and H8 drivers can coexist — check both independently
+        local h10_version="-1"
+        local h8_version="-1"
         if dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep -q "^ii"; then
-            version=$(dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
-            echo "[OK]   h10-hailort-pcie-driver package installed, version: $version"
-        elif dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep -q "^ii"; then
-            version=$(dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
-            echo "[OK]   hailort-pcie-driver package installed, version: $version"
+            h10_version=$(dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
+            echo "[OK]   h10-hailort-pcie-driver package installed, version: $h10_version"
+        fi
+        if dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep -q "^ii"; then
+            h8_version=$(dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
+            echo "[OK]   hailort-pcie-driver package installed, version: $h8_version"
+        fi
+        if [[ "$h10_version" != "-1" ]]; then
+            version="$h10_version"
+        elif [[ "$h8_version" != "-1" ]]; then
+            version="$h8_version"
         else
             echo "[WARN] hailo_pci/hailo1x_pci module not found, version: -1"
         fi

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -341,7 +341,11 @@ check_kernel_module() {
         fi
     else
         # Fallback check for the package if neither module is found
-        if dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep -q "^ii"; then
+        # Check h10-hailort-pcie-driver first (RPi + H10 all 5.x, x86 + H10 from 5.4)
+        if dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep -q "^ii"; then
+            version=$(dpkg -l 2>/dev/null | grep "h10-hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
+            echo "[OK]   h10-hailort-pcie-driver package installed, version: $version"
+        elif dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep -q "^ii"; then
             version=$(dpkg -l 2>/dev/null | grep "hailort-pcie-driver" | grep "^ii" | awk '{print $3}')
             echo "[OK]   hailort-pcie-driver package installed, version: $version"
         else
@@ -369,9 +373,9 @@ check_kernel_module() {
 check_hailort() {
     local hailort_version="-1"
     
-    # Check system installation via apt - handle both regular and versioned packages
-    if dpkg -l 2>/dev/null | grep -E "^ii.*hailort(/| )" | head -1 | grep -q .; then
-        hailort_version=$(dpkg -l | grep -E "^ii.*hailort(/| )" | head -1 | awk '{print $3}')
+    # Check system installation via apt - handle h10-hailort (RPi+H10) and hailort
+    if dpkg -l 2>/dev/null | grep -E "^ii.*(h10-hailort|hailort)(/| )" | grep -v "pcie-driver\|usb-driver" | head -1 | grep -q .; then
+        hailort_version=$(dpkg -l | grep -E "^ii.*(h10-hailort|hailort)(/| )" | grep -v "pcie-driver\|usb-driver" | head -1 | awk '{print $3}')
         echo "[OK]   hailort (system) version: $hailort_version"
     # Check with hailortcli if available
     elif command -v hailortcli >/dev/null 2>&1; then

--- a/scripts/uninstall_hailo_packages.sh
+++ b/scripts/uninstall_hailo_packages.sh
@@ -16,9 +16,15 @@ fi
 echo "Trying to remove pip packages as root..."
 pip uninstall -y --break-system-packages hailo-apps-core-python-binding hailo-tappas-core-python-binding hailort 2>/dev/null || true
 
-# Uninstall apt packages
+# Uninstall apt packages (meta-packages first to unblock reverse-deps)
 echo "Removing apt packages..."
-sudo apt purge -y hailo-apps-core hailo-tappas-core hailort h10-hailort hailort-pcie-driver h10-hailort-pcie-driver 2>/dev/null || true
+sudo apt purge -y \
+    hailo-h10-all hailo-all \
+    hailo-apps-core hailo-tappas-core \
+    h10-hailort hailort \
+    h10-hailort-pcie-driver hailort-pcie-driver \
+    || true
+sudo apt autoremove -y || true
 
 # Remove kernel modules
 echo "Removing kernel modules..."

--- a/scripts/uninstall_hailo_packages.sh
+++ b/scripts/uninstall_hailo_packages.sh
@@ -18,7 +18,7 @@ pip uninstall -y --break-system-packages hailo-apps-core-python-binding hailo-ta
 
 # Uninstall apt packages
 echo "Removing apt packages..."
-sudo apt purge -y hailo-apps-core hailo-tappas-core hailort hailort-pcie-driver 2>/dev/null || true
+sudo apt purge -y hailo-apps-core hailo-tappas-core hailort h10-hailort hailort-pcie-driver h10-hailort-pcie-driver 2>/dev/null || true
 
 # Remove kernel modules
 echo "Removing kernel modules..."


### PR DESCRIPTION
On Raspberry Pi + Hailo-10H, the PCIe driver package is named h10-hailort-pcie-driver (for all HailoRT 5.x versions). On x86 + Hailo-10H, h10-hailort-pcie-driver is used from HailoRT 5.4+.

Changes:
- install.sh: check h10-hailort-pcie-driver before falling back to hailort-pcie-driver; also check h10-hailort for runtime package
- check_installed_packages.sh: check h10-hailort-pcie-driver in kernel module fallback; update hailort detection regex
- defines.py: add HAILORT_PCIE_DRIVER_PACKAGE_NAME and HAILORT_PCIE_DRIVER_PACKAGE_NAME_H10 constants
- uninstall_hailo_packages.sh: include h10 package names in purge