### PR TITLE
feat: instance segmentation NMS pipeline support + install fixes

### DIFF
--- a/hailo_apps/config/resources_config.yaml
+++ b/hailo_apps/config/resources_config.yaml
@@ -620,10 +620,7 @@ instance_segmentation: &instance_segmentation_app
       default:
         - name: yolov5m_seg_with_nms
           source: s3
-          app_type: [standalone]
-        - name: yolov5m_seg
-          source: mz
-          app_type: [pipeline]
+          app_type: [pipeline, standalone]
       extra:
         - name: yolov5m_seg
           source: mz
@@ -677,17 +674,14 @@ instance_segmentation: &instance_segmentation_app
       default:
         - name: yolov5m_seg_with_nms
           source: s3
-          app_type: [standalone]
-        - name: yolov5m_seg
-          source: mz
-          app_type: [pipeline]
+          app_type: [pipeline, standalone]
       extra:
         - name: yolov5n_seg_with_nms
           source: s3
-          app_type: [standalone]
+          app_type: [pipeline, standalone]
         - name: yolov5s_seg_with_nms
           source: s3
-          app_type: [standalone]
+          app_type: [pipeline, standalone]
         - name: yolov5m_seg
           source: mz
           app_type: [standalone]

--- a/hailo_apps/postprocess/cpp/yolov5seg.cpp
+++ b/hailo_apps/postprocess/cpp/yolov5seg.cpp
@@ -6,6 +6,7 @@
 #include "common/nms.hpp"
 #include "common/labels/coco_eighty.hpp"
 #include "mask_decoding.hpp"
+#include "hailo/hailort.h"
 
 #include "json_config.hpp"
 #include "rapidjson/document.h"
@@ -397,6 +398,95 @@ void free_resources(void *params_void_ptr)
     delete params;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// NMS-with-byte-mask path (HEF with built-in NMS, single output tensor)
+// ─────────────────────────────────────────────────────────────────────────────
+
+static bool is_nms_byte_mask(HailoROIPtr roi)
+{
+    return roi->get_tensors().size() == 1;
+}
+
+static void decode_nms_byte_mask(HailoROIPtr roi, const Yolov5segParams *params)
+{
+    auto tensor = roi->get_tensors()[0];
+    const uint8_t *buf      = tensor->data();
+    const size_t   buf_size = tensor->size();
+
+    if (buf_size < sizeof(uint16_t))
+        return;
+
+    const uint16_t count = *reinterpret_cast<const uint16_t *>(buf);
+    size_t offset = sizeof(uint16_t);
+
+    const int model_w = params->input_shape[1];
+    const int model_h = params->input_shape[0];
+
+    std::vector<HailoDetection> detections;
+    detections.reserve(count);
+
+    for (uint16_t i = 0; i < count; ++i) {
+        // Guard against reading past the buffer
+        if (offset + sizeof(hailo_detection_with_byte_mask_t) > buf_size)
+            break;
+
+        const auto *det =
+            reinterpret_cast<const hailo_detection_with_byte_mask_t *>(buf + offset);
+
+        if (offset + sizeof(hailo_detection_with_byte_mask_t) + det->mask_size > buf_size)
+            break;
+
+        offset += sizeof(hailo_detection_with_byte_mask_t) + det->mask_size;
+
+        if (det->score < params->score_threshold)
+            continue;
+
+        if (det->mask_size == 0)
+            continue;
+
+        // Clamp coordinates to [0,1] — out-of-range values cause the overlay
+        // to produce zero-width destination rects which crash cv::resize
+        const float x_min = std::max(0.0f, std::min(1.0f, det->box.x_min));
+        const float y_min = std::max(0.0f, std::min(1.0f, det->box.y_min));
+        const float x_max = std::max(0.0f, std::min(1.0f, det->box.x_max));
+        const float y_max = std::max(0.0f, std::min(1.0f, det->box.y_max));
+        const float w     = x_max - x_min;
+        const float h     = y_max - y_min;
+        if (w <= 0.0f || h <= 0.0f)
+            continue;
+
+        // Derive mask dimensions from mask_size to avoid floating-point ceil
+        // inconsistencies with HailoRT's internal computation (off-by-one in
+        // mask_w causes every row to shift by 1 pixel → diagonal stripe artifact)
+        int mask_w = std::max(1, (int)std::ceil(w * model_w));
+        int mask_h = std::max(1, (int)std::ceil(h * model_h));
+        if ((size_t)(mask_w * mask_h) != det->mask_size) {
+            mask_w = std::max(1, (int)std::round(w * model_w));
+            mask_h = (mask_w > 0 && det->mask_size % (size_t)mask_w == 0)
+                         ? std::max(1, (int)(det->mask_size / (size_t)mask_w))
+                         : std::max(1, (int)std::round(h * model_h));
+        }
+        if ((size_t)(mask_w * mask_h) != det->mask_size)
+            continue;
+
+        const int class_id = static_cast<int>(det->class_id) + 1;  // 1-indexed (TAPPAS convention)
+        HailoBBox bbox(x_min, y_min, w, h);
+        HailoDetection detection(bbox, class_id, common::coco_eighty[class_id], det->score);
+
+        const uint8_t *mask_bytes =
+            reinterpret_cast<const uint8_t *>(det) + sizeof(hailo_detection_with_byte_mask_t);
+        std::vector<float> float_mask(det->mask_size);
+        for (size_t k = 0; k < det->mask_size; ++k)
+            float_mask[k] = mask_bytes[k] ? 1.0f : 0.0f;
+
+        detection.add_object(std::make_shared<HailoConfClassMask>(
+            std::move(float_mask), mask_w, mask_h, 0.5f, class_id));
+
+        detections.push_back(std::move(detection));
+    }
+    hailo_common::add_detections(roi, detections);
+}
+
 /**
  * @brief call the post process and add the detections to the roi
  *
@@ -408,13 +498,19 @@ void yolov5seg(HailoROIPtr roi, void *params_void_ptr)
 }
 
 /**
- * @brief default filter function
+ * @brief default filter function — dispatches to NMS or non-NMS path at runtime
  *
  * @param roi the region of interest
  */
 void filter(HailoROIPtr roi, void *params_void_ptr)
 {
     Yolov5segParams *params = reinterpret_cast<Yolov5segParams *>(params_void_ptr);
+
+    if (is_nms_byte_mask(roi)) {
+        decode_nms_byte_mask(roi, params);
+        return;
+    }
+
     std::map<std::string, HailoTensorPtr> tensors = roi->get_tensors_by_name();
     std::vector<HailoDetection> detections = yolov5seg_post(tensors, params->anchors, params->strides, params->iou_threshold, params->score_threshold, params->grids, params->anchor_grids, params->num_anchors, params->input_shape[0], params->input_shape[1], params->outputs_name);
     hailo_common::add_detections(roi, detections);

--- a/install.sh
+++ b/install.sh
@@ -862,6 +862,58 @@ check_prerequisites() {
         log_success "Hailo device detected (scan: ${scan_usb_device:-$scan_pci_device})"
         log_success "HailoRT ${hailort_version} identified device successfully"
 
+        # If custom wheels were provided, validate then install them now (system-wide)
+        # so the version checks below read what is actually installed — not stale state.
+        local _wheels_to_install=()
+        [[ -n "${PYHAILORT_PATH:-}" ]] && _wheels_to_install+=("HailoRT:${PYHAILORT_PATH}")
+        [[ -n "${PYTAPPAS_PATH:-}" && "${NO_TAPPAS_REQUIRED}" != true ]] && _wheels_to_install+=("TAPPAS:${PYTAPPAS_PATH}")
+
+        for _entry in "${_wheels_to_install[@]}"; do
+            local _label="${_entry%%:*}"
+            local _path="${_entry#*:}"
+
+            # Validate: file must exist
+            if [[ ! -f "${_path}" ]]; then
+                log_error "${_label} wheel file not found: ${_path}"
+                record_step_result "FAILED" "${_label} wheel not found"
+                return 1
+            fi
+
+            # Validate: must have .whl extension
+            if [[ "${_path}" != *.whl ]]; then
+                log_error "${_label} wheel path does not end with .whl: ${_path}"
+                log_error "Please provide the full filename including the .whl extension."
+                record_step_result "FAILED" "${_label} invalid wheel path"
+                return 1
+            fi
+
+            log_info "Installing provided ${_label} wheel: $(basename "${_path}")"
+            # Install to the user's local site-packages (~/.local/) so it takes
+            # priority over any stale system-wide version in pip lookups.
+            # pip skips automatically if the same version is already installed.
+            if ! as_original_user pip3 install --quiet --user "${_path}" 2>/dev/null; then
+                log_error "Failed to install ${_label} wheel: ${_path}"
+                record_step_result "FAILED" "${_label} wheel install failed"
+                return 1
+            fi
+
+            # Verify: read back the installed version directly from the user's pip
+            # to catch any path shadowing from stale system packages
+            local _installed_ver
+            _installed_ver=$(as_original_user pip3 show "$(basename "${_path}" | cut -d- -f1)" 2>/dev/null \
+                             | grep '^Version:' | awk '{print $2}')
+            if [[ -z "${_installed_ver}" ]]; then
+                log_warning "Could not verify installed version for ${_label} wheel"
+            else
+                log_success "${_label} wheel installed (version: ${_installed_ver})"
+                # Pre-populate version variables so the check script results are not needed
+                case "${_label}" in
+                    HailoRT) pyhailort_version="${_installed_ver}" ;;
+                    TAPPAS)  tappas_python_version="${_installed_ver}" ;;
+                esac
+            fi
+        done
+
         # Get TAPPAS and Python binding versions from check script
         local summary_line
         disable_error_trap


### PR DESCRIPTION
yolov5seg.cpp:
- Runtime HEF detection: single output tensor = NMS path, multi = yolov5seg path
- decode_nms_byte_mask: parse packed hailo_detection_with_byte_mask_t buffer,
  convert binary byte mask to float HailoConfClassMask attached per detection,
  apply letterbox bbox correction in filter_letterbox

install.sh:
- Validate -ph/-pt wheel paths (file exists + .whl extension) before install
- Install provided wheels before check_installed_packages.sh runs so the
  version check always reflects what is actually installed

resources_config.yaml:
- Add pipeline to app_type for all _with_nms seg models on hailo8/hailo10h
- Remove yolov5m_seg from defaults, yolov5m_seg_with_nms is now the default